### PR TITLE
Add: Autodetect OpenVZ/Virtuozzo VPS

### DIFF
--- a/files/internals/internals.conf
+++ b/files/internals/internals.conf
@@ -21,6 +21,11 @@ WGET=`which wget 2> /dev/null`
 MD5=`which md5sum 2> /dev/null`
 UNAME=`which uname 2> /dev/null`
 
+## Force MONOKERN option on Virtuozzo/OpenVZ based VPS
+if [ -d /proc/vz -a ! -d /proc/bc ]; then
+        SET_MONOKERN="1"
+fi
+
 ## LEGACY VARIABLE DEFINITIONS
 if [ -z "$IFACE_UNTRUSTED" ] && [ "$IFACE_IN" ]; then
 	IFACE_UNTRUSTED="$IFACE_IN"


### PR DESCRIPTION
Problem: APF does not run with default options on OpenVZ/Virtuozzo VPS
Solution: Autodetect if host is a OpenVZ/Virtuozzo based virtual machine and force monokern workaround