### PR TITLE
[Fix] Syntax fix. Bash globbing does not accept spaces between var="s…

### DIFF
--- a/files/sysctl.rules
+++ b/files/sysctl.rules
@@ -2,8 +2,8 @@ eout "{glob} loading sysctl.rules"
 
 # START SYSCTL config
 
-if [ "$SYSCTL_CONNTRACK" == "" ]; then
-	SYSCTL_CONNTRACK = 65536
+if [ "$SYSCTL_CONNTRACK" == "" ] || [ -z "$SYSCTL_CONNTRACK" ]; then
+	SYSCTL_CONNTRACK=65536
 fi
 
 if [ -f "/proc/sys/net/ipv4/ip_conntrack_max" ]; then


### PR DESCRIPTION
…tring"

Syntax error presents if spaces are present between variable and it's newly set value. Since firewall pipes things to /dev/null we haven't seen any errors, until we noticed the value was not being properly updated by APF. Also if the variable is commented out in conf.apf this will not trigger the setting as it is unset versus empty, so an additional or is provided empty or unset.