### PR TITLE
Fix bug where IP's are interpreted as regexen

### DIFF
--- a/files/internals/functions.apf
+++ b/files/internals/functions.apf
@@ -168,7 +168,7 @@ cli_trust() {
  HOST="$4"
  CMT="$5"
  if [ ! "$HOST" == "" ]; then
-        valtrust=`cat $DENY_HOSTS $ALLOW_HOSTS $GALLOW_HOSTS $GDENY_HOSTS | grep -w $HOST`
+        valtrust=`cat $DENY_HOSTS $ALLOW_HOSTS $GALLOW_HOSTS $GDENY_HOSTS | grep -F -w $HOST`
 	if [ "$valtrust" ]; then
 		tlist=`grep -l $HOST $DENY_HOSTS $ALLOW_HOSTS $GALLOW_HOSTS $GDENY_HOSTS | tr '\n' ' '`
 	fi


### PR DESCRIPTION
Attempting to block 1.1.1.1 will fail if the IP 2.3.141.121 is already in the system with error "already exists".

The -F option of grep makes the IP be interpreted as a literal string.