### PR TITLE
Add support for -w when iptables >= 1.4.20

### DIFF
--- a/apf.init
+++ b/apf.init
@@ -46,10 +46,10 @@ restart)
         $0 start
         ;;
 condrestart)
-	if $ipt -n -L TALLOW > /dev/null 2>&1 && \
-	    $ipt -n -L TDENY > /dev/null 2>&1 && \
-	    $ipt -n -L TGALLOW > /dev/null 2>&1 && \
-	    $ipt -n -L TGDENY > /dev/null 2>&1; then
+	if $ipt $IPT_FLAGS -n -L TALLOW > /dev/null 2>&1 && \
+	    $ipt $IPT_FLAGS -n -L TDENY > /dev/null 2>&1 && \
+	    $ipt $IPT_FLAGS -n -L TGALLOW > /dev/null 2>&1 && \
+	    $ipt $IPT_FLAGS -n -L TGDENY > /dev/null 2>&1; then
 	    $0 stop
 	    $0 start
 	else

--- a/files/apf
+++ b/files/apf
@@ -100,7 +100,7 @@ fi
 if [ "$SKIP_FASTLOAD_FIRSTRUN" == "" ] && [ "$SKIP_FASTLOAD_EXPIRED" == "" ] && [ "$SKIP_FASTLOAD_VARS" == "" ] && [ "$SET_FASTLOAD_UPSEC" == "" ]; then
 	devm
 	eout "{glob} activating firewall, fast load"
-	$IPTR $INSTALL_PATH/internals/.apf.restore
+	$IPTR $IPT_FLAGS $INSTALL_PATH/internals/.apf.restore
 	eout "{glob} firewall initialized"
 	if [ "$SET_VERBOSE" == "1" ] && [ "$DEVEL_ON" == "1" ]; then
 	        eout "{glob} !!DEVELOPMENT MODE ENABLED!! - firewall will flush every 5 minutes."
@@ -152,7 +152,7 @@ if [ "$MD5_FIRSTRUN" == "1" ]; then
         $MD5 $MD5_FILES > $INSTALL_PATH/internals/.md5.cores 2> /dev/null
 fi
 
-firewall_on=`iptables -L --numeric | grep -vE "Chain|destination"`
+firewall_on=`$IPT $IPT_FLAGS -L --numeric | grep -vE "Chain|destination"`
 if [ ! "$DEVEL_ON" == "1" ] && [ ! "$firewall_on" == "" ]; then
 	$IPTS > $INSTALL_PATH/internals/.apf.restore
 	eout "{glob} fast load snapshot saved"

--- a/files/bt.rules
+++ b/files/bt.rules
@@ -45,84 +45,84 @@ if [ "$PKT_SANITY" == "1" ]; then
         eout "{pkt_sanity} deny inbound tcp-flag pairs ALL SYN,RST,ACK,FIN,URG"
         eout "{pkt_sanity} deny inbound tcp-flag pairs ALL ALL"
         eout "{pkt_sanity} deny inbound tcp-flag pairs ALL FIN"
-        $IPT -N IN_SANITY
+        $IPT $IPT_FLAGS -N IN_SANITY
         if [ "$LOG_DROP" == "1" ]; then
-         $IPT -A IN_SANITY  -p tcp --tcp-flags ALL NONE -m limit --limit=$LOG_RATE/minute -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix="** SANITY ** "
+         $IPT $IPT_FLAGS -A IN_SANITY  -p tcp --tcp-flags ALL NONE -m limit --limit=$LOG_RATE/minute -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix="** SANITY ** "
 	fi
         if [ "$RAB_LOG_HIT" == "1" ]; then
-         $IPT -A IN_SANITY  -p tcp --tcp-flags ALL NONE -m limit --limit=$LOG_RATE/minute -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix="** RABHIT ** "
+         $IPT $IPT_FLAGS -A IN_SANITY  -p tcp --tcp-flags ALL NONE -m limit --limit=$LOG_RATE/minute -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix="** RABHIT ** "
 	fi
-        $IPT -A IN_SANITY  -p tcp --tcp-flags ALL NONE $RAB_SANITY_FLAGS -j $TCP_STOP
+        $IPT $IPT_FLAGS -A IN_SANITY  -p tcp --tcp-flags ALL NONE $RAB_SANITY_FLAGS -j $TCP_STOP
         if [ "$LOG_DROP" == "1" ]; then
-         $IPT -A IN_SANITY  -p tcp --tcp-flags SYN,FIN SYN,FIN -m limit --limit=$LOG_RATE/minute -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix="** SANITY ** "
+         $IPT $IPT_FLAGS -A IN_SANITY  -p tcp --tcp-flags SYN,FIN SYN,FIN -m limit --limit=$LOG_RATE/minute -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix="** SANITY ** "
 	fi
         if [ "$RAB_LOG_HIT" == "1" ]; then
-         $IPT -A IN_SANITY  -p tcp --tcp-flags SYN,FIN SYN,FIN -m limit --limit=$LOG_RATE/minute -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix="** RABHIT ** "
+         $IPT $IPT_FLAGS -A IN_SANITY  -p tcp --tcp-flags SYN,FIN SYN,FIN -m limit --limit=$LOG_RATE/minute -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix="** RABHIT ** "
 	fi
-        $IPT -A IN_SANITY  -p tcp --tcp-flags SYN,FIN SYN,FIN $RAB_SANITY_FLAGS -j $TCP_STOP
+        $IPT $IPT_FLAGS -A IN_SANITY  -p tcp --tcp-flags SYN,FIN SYN,FIN $RAB_SANITY_FLAGS -j $TCP_STOP
         if [ "$LOG_DROP" == "1" ]; then
-         $IPT -A IN_SANITY  -p tcp --tcp-flags SYN,RST SYN,RST -m limit --limit=$LOG_RATE/minute -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix="** SANITY ** "
+         $IPT $IPT_FLAGS -A IN_SANITY  -p tcp --tcp-flags SYN,RST SYN,RST -m limit --limit=$LOG_RATE/minute -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix="** SANITY ** "
 	fi
         if [ "$RAB_LOG_HIT" == "1" ]; then
-         $IPT -A IN_SANITY  -p tcp --tcp-flags SYN,RST SYN,RST -m limit --limit=$LOG_RATE/minute -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix="** RABHIT ** "
+         $IPT $IPT_FLAGS -A IN_SANITY  -p tcp --tcp-flags SYN,RST SYN,RST -m limit --limit=$LOG_RATE/minute -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix="** RABHIT ** "
 	fi
-        $IPT -A IN_SANITY  -p tcp --tcp-flags SYN,RST SYN,RST $RAB_SANITY_FLAGS -j $TCP_STOP
+        $IPT $IPT_FLAGS -A IN_SANITY  -p tcp --tcp-flags SYN,RST SYN,RST $RAB_SANITY_FLAGS -j $TCP_STOP
         if [ "$LOG_DROP" == "1" ]; then
-         $IPT -A IN_SANITY  -p tcp --tcp-flags FIN,RST FIN,RST -m limit --limit=$LOG_RATE/minute -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix="** SANITY ** "
+         $IPT $IPT_FLAGS -A IN_SANITY  -p tcp --tcp-flags FIN,RST FIN,RST -m limit --limit=$LOG_RATE/minute -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix="** SANITY ** "
 	fi
         if [ "$RAB_LOG_HIT" == "1" ]; then
-         $IPT -A IN_SANITY  -p tcp --tcp-flags FIN,RST FIN,RST -m limit --limit=$LOG_RATE/minute -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix="** RABHIT ** "
+         $IPT $IPT_FLAGS -A IN_SANITY  -p tcp --tcp-flags FIN,RST FIN,RST -m limit --limit=$LOG_RATE/minute -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix="** RABHIT ** "
 	fi
-        $IPT -A IN_SANITY  -p tcp --tcp-flags FIN,RST FIN,RST $RAB_SANITY_FLAGS -j $TCP_STOP
+        $IPT $IPT_FLAGS -A IN_SANITY  -p tcp --tcp-flags FIN,RST FIN,RST $RAB_SANITY_FLAGS -j $TCP_STOP
         if [ "$LOG_DROP" == "1" ]; then
-         $IPT -A IN_SANITY  -p tcp --tcp-flags ACK,FIN FIN -m limit --limit=$LOG_RATE/minute -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix="** SANITY ** "
+         $IPT $IPT_FLAGS -A IN_SANITY  -p tcp --tcp-flags ACK,FIN FIN -m limit --limit=$LOG_RATE/minute -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix="** SANITY ** "
 	fi
         if [ "$RAB_LOG_HIT" == "1" ]; then
-         $IPT -A IN_SANITY  -p tcp --tcp-flags ACK,FIN FIN -m limit --limit=$LOG_RATE/minute -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix="** RABHIT ** "
+         $IPT $IPT_FLAGS -A IN_SANITY  -p tcp --tcp-flags ACK,FIN FIN -m limit --limit=$LOG_RATE/minute -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix="** RABHIT ** "
 	fi
-        $IPT -A IN_SANITY  -p tcp --tcp-flags ACK,FIN FIN $RAB_SANITY_FLAGS -j $TCP_STOP
+        $IPT $IPT_FLAGS -A IN_SANITY  -p tcp --tcp-flags ACK,FIN FIN $RAB_SANITY_FLAGS -j $TCP_STOP
         if [ "$LOG_DROP" == "1" ]; then
-         $IPT -A IN_SANITY  -p tcp --tcp-flags ACK,URG URG -m limit --limit=$LOG_RATE/minute -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix="** SANITY ** "
+         $IPT $IPT_FLAGS -A IN_SANITY  -p tcp --tcp-flags ACK,URG URG -m limit --limit=$LOG_RATE/minute -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix="** SANITY ** "
 	fi
         if [ "$RAB_LOG_HIT" == "1" ]; then
-         $IPT -A IN_SANITY  -p tcp --tcp-flags ACK,URG URG -m limit --limit=$LOG_RATE/minute -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix="** RABHIT ** "
+         $IPT $IPT_FLAGS -A IN_SANITY  -p tcp --tcp-flags ACK,URG URG -m limit --limit=$LOG_RATE/minute -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix="** RABHIT ** "
 	fi
-        $IPT -A IN_SANITY  -p tcp --tcp-flags ACK,URG URG $RAB_SANITY_FLAGS -j $TCP_STOP
+        $IPT $IPT_FLAGS -A IN_SANITY  -p tcp --tcp-flags ACK,URG URG $RAB_SANITY_FLAGS -j $TCP_STOP
         if [ "$LOG_DROP" == "1" ]; then
-         $IPT -A IN_SANITY  -p tcp --tcp-flags ACK,PSH PSH -m limit --limit=$LOG_RATE/minute -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix="** SANITY ** "
+         $IPT $IPT_FLAGS -A IN_SANITY  -p tcp --tcp-flags ACK,PSH PSH -m limit --limit=$LOG_RATE/minute -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix="** SANITY ** "
 	fi
         if [ "$RAB_LOG_HIT" == "1" ]; then
-         $IPT -A IN_SANITY  -p tcp --tcp-flags ACK,PSH PSH -m limit --limit=$LOG_RATE/minute -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix="** RABHIT ** "
+         $IPT $IPT_FLAGS -A IN_SANITY  -p tcp --tcp-flags ACK,PSH PSH -m limit --limit=$LOG_RATE/minute -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix="** RABHIT ** "
 	fi
-        $IPT -A IN_SANITY  -p tcp --tcp-flags ACK,PSH PSH $RAB_SANITY_FLAGS -j $TCP_STOP
+        $IPT $IPT_FLAGS -A IN_SANITY  -p tcp --tcp-flags ACK,PSH PSH $RAB_SANITY_FLAGS -j $TCP_STOP
         if [ "$LOG_DROP" == "1" ]; then
-         $IPT -A IN_SANITY  -p tcp --tcp-flags ALL FIN,URG,PSH -m limit --limit=$LOG_RATE/minute -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix="** SANITY ** "
+         $IPT $IPT_FLAGS -A IN_SANITY  -p tcp --tcp-flags ALL FIN,URG,PSH -m limit --limit=$LOG_RATE/minute -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix="** SANITY ** "
 	fi
         if [ "$RAB_LOG_HIT" == "1" ]; then
-         $IPT -A IN_SANITY  -p tcp --tcp-flags ALL FIN,URG,PSH -m limit --limit=$LOG_RATE/minute -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix="** RABHIT ** "
+         $IPT $IPT_FLAGS -A IN_SANITY  -p tcp --tcp-flags ALL FIN,URG,PSH -m limit --limit=$LOG_RATE/minute -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix="** RABHIT ** "
 	fi
-        $IPT -A IN_SANITY  -p tcp --tcp-flags ALL FIN,URG,PSH $RAB_SANITY_FLAGS -j $TCP_STOP
+        $IPT $IPT_FLAGS -A IN_SANITY  -p tcp --tcp-flags ALL FIN,URG,PSH $RAB_SANITY_FLAGS -j $TCP_STOP
         if [ "$LOG_DROP" == "1" ]; then
-         $IPT -A IN_SANITY  -p tcp --tcp-flags ALL SYN,RST,ACK,FIN,URG -m limit --limit=$LOG_RATE/minute -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix="** SANITY ** "
+         $IPT $IPT_FLAGS -A IN_SANITY  -p tcp --tcp-flags ALL SYN,RST,ACK,FIN,URG -m limit --limit=$LOG_RATE/minute -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix="** SANITY ** "
 	fi
         if [ "$RAB_LOG_HIT" == "1" ]; then
-         $IPT -A IN_SANITY  -p tcp --tcp-flags ALL SYN,RST,ACK,FIN,URG -m limit --limit=$LOG_RATE/minute -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix="** RABHIT ** "
+         $IPT $IPT_FLAGS -A IN_SANITY  -p tcp --tcp-flags ALL SYN,RST,ACK,FIN,URG -m limit --limit=$LOG_RATE/minute -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix="** RABHIT ** "
 	fi
-        $IPT -A IN_SANITY  -p tcp --tcp-flags ALL SYN,RST,ACK,FIN,URG $RAB_SANITY_FLAGS -j $TCP_STOP
+        $IPT $IPT_FLAGS -A IN_SANITY  -p tcp --tcp-flags ALL SYN,RST,ACK,FIN,URG $RAB_SANITY_FLAGS -j $TCP_STOP
         if [ "$LOG_DROP" == "1" ]; then
-         $IPT -A IN_SANITY  -p tcp --tcp-flags ALL ALL -m limit --limit=$LOG_RATE/minute -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix="** SANITY ** "
+         $IPT $IPT_FLAGS -A IN_SANITY  -p tcp --tcp-flags ALL ALL -m limit --limit=$LOG_RATE/minute -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix="** SANITY ** "
 	fi
         if [ "$RAB_LOG_HIT" == "1" ]; then
-         $IPT -A IN_SANITY  -p tcp --tcp-flags ALL ALL -m limit --limit=$LOG_RATE/minute -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix="** RABHIT ** "
+         $IPT $IPT_FLAGS -A IN_SANITY  -p tcp --tcp-flags ALL ALL -m limit --limit=$LOG_RATE/minute -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix="** RABHIT ** "
 	fi
-        $IPT -A IN_SANITY  -p tcp --tcp-flags ALL ALL $RAB_SANITY_FLAGS -j $TCP_STOP
+        $IPT $IPT_FLAGS -A IN_SANITY  -p tcp --tcp-flags ALL ALL $RAB_SANITY_FLAGS -j $TCP_STOP
         if [ "$LOG_DROP" == "1" ]; then
-         $IPT -A IN_SANITY  -p tcp --tcp-flags ALL FIN -m limit --limit=$LOG_RATE/minute -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix="** SANITY ** "
+         $IPT $IPT_FLAGS -A IN_SANITY  -p tcp --tcp-flags ALL FIN -m limit --limit=$LOG_RATE/minute -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix="** SANITY ** "
 	fi
         if [ "$RAB_LOG_HIT" == "1" ]; then
-         $IPT -A IN_SANITY  -p tcp --tcp-flags ALL FIN -m limit --limit=$LOG_RATE/minute -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix="** RABHIT ** "
+         $IPT $IPT_FLAGS -A IN_SANITY  -p tcp --tcp-flags ALL FIN -m limit --limit=$LOG_RATE/minute -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix="** RABHIT ** "
 	fi
-        $IPT -A IN_SANITY  -p tcp --tcp-flags ALL FIN $RAB_SANITY_FLAGS -j $TCP_STOP
+        $IPT $IPT_FLAGS -A IN_SANITY  -p tcp --tcp-flags ALL FIN $RAB_SANITY_FLAGS -j $TCP_STOP
 
         eout "{pkt_sanity} deny outbound tcp-flag pairs ALL NONE"
         eout "{pkt_sanity} deny outbound tcp-flag pairs SYN,FIN SYN,FIN"
@@ -131,35 +131,35 @@ if [ "$PKT_SANITY" == "1" ]; then
         eout "{pkt_sanity} deny outbound tcp-flag pairs ACK,FIN FIN"
         eout "{pkt_sanity} deny outbound tcp-flag pairs ACK,PSH PSH"
         eout "{pkt_sanity} deny outbound tcp-flag pairs ACK,URG URG"
-	$IPT -N OUT_SANITY
+	$IPT $IPT_FLAGS -N OUT_SANITY
         if [ "$LOG_DROP" == "1" ]; then
-	 $IPT -A OUT_SANITY  -p tcp --tcp-flags ALL NONE -m limit --limit=$LOG_RATE/minute -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix="** SANITY ** "
+	 $IPT $IPT_FLAGS -A OUT_SANITY  -p tcp --tcp-flags ALL NONE -m limit --limit=$LOG_RATE/minute -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix="** SANITY ** "
 	fi
-	$IPT -A OUT_SANITY  -p tcp --tcp-flags ALL NONE -j $TCP_STOP
+	$IPT $IPT_FLAGS -A OUT_SANITY  -p tcp --tcp-flags ALL NONE -j $TCP_STOP
         if [ "$LOG_DROP" == "1" ]; then
-	 $IPT -A OUT_SANITY  -p tcp --tcp-flags SYN,FIN SYN,FIN -m limit --limit=$LOG_RATE/minute -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix="** SANITY ** "
+	 $IPT $IPT_FLAGS -A OUT_SANITY  -p tcp --tcp-flags SYN,FIN SYN,FIN -m limit --limit=$LOG_RATE/minute -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix="** SANITY ** "
 	fi
-	$IPT -A OUT_SANITY  -p tcp --tcp-flags SYN,FIN SYN,FIN -j $TCP_STOP
+	$IPT $IPT_FLAGS -A OUT_SANITY  -p tcp --tcp-flags SYN,FIN SYN,FIN -j $TCP_STOP
         if [ "$LOG_DROP" == "1" ]; then
-	 $IPT -A OUT_SANITY  -p tcp --tcp-flags SYN,RST SYN,RST -m limit --limit=$LOG_RATE/minute -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix="** SANITY ** "
+	 $IPT $IPT_FLAGS -A OUT_SANITY  -p tcp --tcp-flags SYN,RST SYN,RST -m limit --limit=$LOG_RATE/minute -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix="** SANITY ** "
 	fi
-	$IPT -A OUT_SANITY  -p tcp --tcp-flags SYN,RST SYN,RST -j $TCP_STOP
+	$IPT $IPT_FLAGS -A OUT_SANITY  -p tcp --tcp-flags SYN,RST SYN,RST -j $TCP_STOP
         if [ "$LOG_DROP" == "1" ]; then
-	 $IPT -A OUT_SANITY  -p tcp --tcp-flags FIN,RST FIN,RST -m limit --limit=$LOG_RATE/minute -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix="** SANITY ** "
+	 $IPT $IPT_FLAGS -A OUT_SANITY  -p tcp --tcp-flags FIN,RST FIN,RST -m limit --limit=$LOG_RATE/minute -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix="** SANITY ** "
 	fi
-	$IPT -A OUT_SANITY  -p tcp --tcp-flags FIN,RST FIN,RST -j $TCP_STOP
+	$IPT $IPT_FLAGS -A OUT_SANITY  -p tcp --tcp-flags FIN,RST FIN,RST -j $TCP_STOP
         if [ "$LOG_DROP" == "1" ]; then
-	 $IPT -A OUT_SANITY  -p tcp --tcp-flags ACK,FIN FIN -m limit --limit=$LOG_RATE/minute -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix="** SANITY ** "
+	 $IPT $IPT_FLAGS -A OUT_SANITY  -p tcp --tcp-flags ACK,FIN FIN -m limit --limit=$LOG_RATE/minute -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix="** SANITY ** "
 	fi
-	$IPT -A OUT_SANITY  -p tcp --tcp-flags ACK,FIN FIN -j $TCP_STOP
+	$IPT $IPT_FLAGS -A OUT_SANITY  -p tcp --tcp-flags ACK,FIN FIN -j $TCP_STOP
         if [ "$LOG_DROP" == "1" ]; then
-	 $IPT -A OUT_SANITY  -p tcp --tcp-flags ACK,PSH PSH -m limit --limit=$LOG_RATE/minute -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix="** SANITY ** "
+	 $IPT $IPT_FLAGS -A OUT_SANITY  -p tcp --tcp-flags ACK,PSH PSH -m limit --limit=$LOG_RATE/minute -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix="** SANITY ** "
 	fi
-	$IPT -A OUT_SANITY -p tcp --tcp-flags ACK,PSH PSH -j $TCP_STOP
+	$IPT $IPT_FLAGS -A OUT_SANITY -p tcp --tcp-flags ACK,PSH PSH -j $TCP_STOP
         if [ "$LOG_DROP" == "1" ]; then
-	 $IPT -A OUT_SANITY -p tcp --tcp-flags ACK,URG URG -m limit --limit=$LOG_RATE/minute -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix="** SANITY ** "
+	 $IPT $IPT_FLAGS -A OUT_SANITY -p tcp --tcp-flags ACK,URG URG -m limit --limit=$LOG_RATE/minute -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix="** SANITY ** "
 	fi
-	$IPT -A OUT_SANITY -p tcp --tcp-flags ACK,URG URG -j $TCP_STOP
+	$IPT $IPT_FLAGS -A OUT_SANITY -p tcp --tcp-flags ACK,URG URG -j $TCP_STOP
 
 	if [ "$PKT_SANITY_INV" == "1" ]; then
 	# Block Traffic With Invalid Flags
@@ -168,63 +168,63 @@ if [ "$PKT_SANITY" == "1" ]; then
 	        eout "{pkt_sanity} deny inbound tcp-option 64"
 	        eout "{pkt_sanity} deny inbound tcp-option 128"
 	        if [ "$LOG_DROP" == "1" ]; then
-		 $IPT -A IN_SANITY -m state --state INVALID -m limit --limit=$LOG_RATE/minute -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix="** SANITY ** "
+		 $IPT $IPT_FLAGS -A IN_SANITY -m state --state INVALID -m limit --limit=$LOG_RATE/minute -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix="** SANITY ** "
 		fi
-		$IPT -A IN_SANITY -m state --state INVALID -j $ALL_STOP
+		$IPT $IPT_FLAGS -A IN_SANITY -m state --state INVALID -j $ALL_STOP
                 if [ "$LOG_DROP" == "1" ]; then
-		 $IPT -A IN_SANITY -p tcp --tcp-option 64 -m limit --limit=$LOG_RATE/minute -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix="** SANITY ** "
+		 $IPT $IPT_FLAGS -A IN_SANITY -p tcp --tcp-option 64 -m limit --limit=$LOG_RATE/minute -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix="** SANITY ** "
 		fi
-		$IPT -A IN_SANITY -p tcp --tcp-option 64 -j $TCP_STOP
+		$IPT $IPT_FLAGS -A IN_SANITY -p tcp --tcp-option 64 -j $TCP_STOP
                 if [ "$LOG_DROP" == "1" ]; then
-		 $IPT -A IN_SANITY -p tcp --tcp-option 128 -m limit --limit=$LOG_RATE/minute -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix="** SANITY ** "
+		 $IPT $IPT_FLAGS -A IN_SANITY -p tcp --tcp-option 128 -m limit --limit=$LOG_RATE/minute -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix="** SANITY ** "
 		fi
-		$IPT -A IN_SANITY -p tcp --tcp-option 128 -j $TCP_STOP
+		$IPT $IPT_FLAGS -A IN_SANITY -p tcp --tcp-option 128 -j $TCP_STOP
                 if [ "$LOG_DROP" == "1" ]; then
-		 $IPT -A OUT_SANITY -m state --state INVALID -m limit --limit=$LOG_RATE/minute -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix="** SANITY ** "
+		 $IPT $IPT_FLAGS -A OUT_SANITY -m state --state INVALID -m limit --limit=$LOG_RATE/minute -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix="** SANITY ** "
 		fi
-		$IPT -A OUT_SANITY -m state --state INVALID -j $ALL_STOP
+		$IPT $IPT_FLAGS -A OUT_SANITY -m state --state INVALID -j $ALL_STOP
 	fi
 
-        $IPT -A OUTPUT -j OUT_SANITY
-        $IPT -A INPUT -j IN_SANITY
+        $IPT $IPT_FLAGS -A OUTPUT -j OUT_SANITY
+        $IPT $IPT_FLAGS -A INPUT -j IN_SANITY
 
 	if [ "$PKT_SANITY_FUDP" == "1" ]; then
 		# Block fragmented UDP
 	        eout "{pkt_sanity} deny all fragmented udp"
-		$IPT -N FRAG_UDP
+		$IPT $IPT_FLAGS -N FRAG_UDP
                 if [ "$LOG_DROP" == "1" ]; then
-		 $IPT -A FRAG_UDP -p udp -f -m limit --limit=$LOG_RATE/minute -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix "** UDP Frag ** "
+		 $IPT $IPT_FLAGS -A FRAG_UDP -p udp -f -m limit --limit=$LOG_RATE/minute -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix "** UDP Frag ** "
 		fi
                 if [ "$RAB_LOG_HIT" == "1" ]; then
-		 $IPT -A FRAG_UDP -p udp -f -m limit --limit=$LOG_RATE/minute -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix "** RABHIT ** "
+		 $IPT $IPT_FLAGS -A FRAG_UDP -p udp -f -m limit --limit=$LOG_RATE/minute -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix "** RABHIT ** "
 		fi
-		$IPT -A FRAG_UDP -p udp -f $RAB_SANITY_FLAGS -j $UDP_STOP
-		$IPT -A INPUT -j FRAG_UDP
-		$IPT -A OUTPUT -j FRAG_UDP
+		$IPT $IPT_FLAGS -A FRAG_UDP -p udp -f $RAB_SANITY_FLAGS -j $UDP_STOP
+		$IPT $IPT_FLAGS -A INPUT -j FRAG_UDP
+		$IPT $IPT_FLAGS -A OUTPUT -j FRAG_UDP
 	fi
 	if [ "$PKT_SANITY_PZERO" == "1" ]; then
 		# Block port zero traffic
 	        eout "{pkt_sanity} deny inbound tcp port 0"
 	        eout "{pkt_sanity} deny outbound tcp port 0"
-		$IPT -N PZERO
+		$IPT $IPT_FLAGS -N PZERO
                 if [ "$LOG_DROP" == "1" ]; then
-		 $IPT -A PZERO -p tcp --dport 0 -m limit --limit=$LOG_RATE/minute -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix "** Port Zero ** "
+		 $IPT $IPT_FLAGS -A PZERO -p tcp --dport 0 -m limit --limit=$LOG_RATE/minute -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix "** Port Zero ** "
 		fi
-		$IPT -A PZERO -p tcp --dport 0 $RAB_SANITY_FLAGS -j $TCP_STOP
+		$IPT $IPT_FLAGS -A PZERO -p tcp --dport 0 $RAB_SANITY_FLAGS -j $TCP_STOP
                 if [ "$LOG_DROP" == "1" ]; then
-		 $IPT -A PZERO -p udp --dport 0 -m limit --limit=$LOG_RATE/minute -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix "** Port Zero ** "
+		 $IPT $IPT_FLAGS -A PZERO -p udp --dport 0 -m limit --limit=$LOG_RATE/minute -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix "** Port Zero ** "
 		fi
-		$IPT -A PZERO -p udp --dport 0 $RAB_SANITY_FLAGS -j $UDP_STOP
+		$IPT $IPT_FLAGS -A PZERO -p udp --dport 0 $RAB_SANITY_FLAGS -j $UDP_STOP
                 if [ "$LOG_DROP" == "1" ]; then
-		 $IPT -A PZERO -p tcp --sport 0 -m limit --limit=$LOG_RATE/minute -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix "** Port Zero ** "
+		 $IPT $IPT_FLAGS -A PZERO -p tcp --sport 0 -m limit --limit=$LOG_RATE/minute -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix "** Port Zero ** "
 		fi
-		$IPT -A PZERO -p tcp --sport 0 $RAB_SANITY_FLAGS -j $TCP_STOP
+		$IPT $IPT_FLAGS -A PZERO -p tcp --sport 0 $RAB_SANITY_FLAGS -j $TCP_STOP
                 if [ "$LOG_DROP" == "1" ]; then
-		 $IPT -A PZERO -p udp --sport 0 -m limit --limit=$LOG_RATE/minute -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix "** Port Zero ** "
+		 $IPT $IPT_FLAGS -A PZERO -p udp --sport 0 -m limit --limit=$LOG_RATE/minute -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix "** Port Zero ** "
 		fi
-		$IPT -A PZERO -p udp --sport 0 $RAB_SANITY_FLAGS -j $UDP_STOP
-		$IPT -A INPUT -j PZERO
-		$IPT -A OUTPUT -j PZERO
+		$IPT $IPT_FLAGS -A PZERO -p udp --sport 0 $RAB_SANITY_FLAGS -j $UDP_STOP
+		$IPT $IPT_FLAGS -A INPUT -j PZERO
+		$IPT $IPT_FLAGS -A OUTPUT -j PZERO
 	fi
 fi
 
@@ -233,25 +233,25 @@ if [ "$BLK_IDENT" = "1" ]; then
 	# Reject ident request if not defined in IG_TCP_CPORTS
 	if [ "$(echo $IG_TCP_CPORTS | tr ',' '\n' | grep -w 113)" == "" ]; then
 		eout "{blk_ident} reject all to/from tcp port 113"
-		$IPT -N IDENT
+		$IPT $IPT_FLAGS -N IDENT
                 if [ "$LOG_DROP" == "1" ]; then
-	         $IPT -A IDENT -p tcp -s 0/0 -d 0/0 --dport 113 -m limit --limit=$LOG_RATE/minute -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix "** IDENT ** "
+	         $IPT $IPT_FLAGS -A IDENT -p tcp -s 0/0 -d 0/0 --dport 113 -m limit --limit=$LOG_RATE/minute -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix "** IDENT ** "
 		fi
-	        $IPT -A IDENT -p tcp -s 0/0 -d 0/0 --dport 113 -j REJECT
+	        $IPT $IPT_FLAGS -A IDENT -p tcp -s 0/0 -d 0/0 --dport 113 -j REJECT
                 if [ "$LOG_DROP" == "1" ]; then
-	         $IPT -A IDENT -p tcp -s 0/0 -d 0/0 --sport 113 -m limit --limit=$LOG_RATE/minute -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix "** IDENT ** "
+	         $IPT $IPT_FLAGS -A IDENT -p tcp -s 0/0 -d 0/0 --sport 113 -m limit --limit=$LOG_RATE/minute -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix "** IDENT ** "
 		fi
-	        $IPT -A IDENT -p tcp -s 0/0 -d 0/0 --sport 113 -j REJECT
+	        $IPT $IPT_FLAGS -A IDENT -p tcp -s 0/0 -d 0/0 --sport 113 -j REJECT
                 if [ "$LOG_DROP" == "1" ]; then
-	         $IPT -A IDENT -p udp -s 0/0 -d 0/0 --dport 113 -m limit --limit=$LOG_RATE/minute -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix "** IDENT ** "
+	         $IPT $IPT_FLAGS -A IDENT -p udp -s 0/0 -d 0/0 --dport 113 -m limit --limit=$LOG_RATE/minute -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix "** IDENT ** "
 		fi
-	        $IPT -A IDENT -p udp -s 0/0 -d 0/0 --dport 113 -j REJECT
+	        $IPT $IPT_FLAGS -A IDENT -p udp -s 0/0 -d 0/0 --dport 113 -j REJECT
                 if [ "$LOG_DROP" == "1" ]; then
-	         $IPT -A IDENT -p udp -s 0/0 -d 0/0 --sport 113 -m limit --limit=$LOG_RATE/minute -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix "** IDENT ** "
+	         $IPT $IPT_FLAGS -A IDENT -p udp -s 0/0 -d 0/0 --sport 113 -m limit --limit=$LOG_RATE/minute -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix "** IDENT ** "
 		fi
-	        $IPT -A IDENT -p udp -s 0/0 -d 0/0 --sport 113 -j REJECT
-		$IPT -A INPUT -j IDENT
-		$IPT -A OUTPUT -j IDENT
+	        $IPT $IPT_FLAGS -A IDENT -p udp -s 0/0 -d 0/0 --sport 113 -j REJECT
+		$IPT $IPT_FLAGS -A INPUT -j IDENT
+		$IPT $IPT_FLAGS -A OUTPUT -j IDENT
 	fi
 fi
 
@@ -260,24 +260,24 @@ if [ "$BLK_MCATNET" == "1" ]; then
 	# Block Multicast
 	eout "{blk_mcat} deny all from 224.0.0.0/8"
 	eout "{blk_mcat} deny all to 224.0.0.0/8"
-	$IPT -N MCAST
+	$IPT $IPT_FLAGS -N MCAST
         if [ "$LOG_DROP" == "1" ]; then
-	 $IPT -A MCAST -s 224.0.0.0/8 -d 0/0 -m limit --limit=$LOG_RATE/minute -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix "** MCAST ** "
+	 $IPT $IPT_FLAGS -A MCAST -s 224.0.0.0/8 -d 0/0 -m limit --limit=$LOG_RATE/minute -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix "** MCAST ** "
 	fi
-	$IPT -A MCAST -s 224.0.0.0/8 -d 0/0 -j $ALL_STOP
+	$IPT $IPT_FLAGS -A MCAST -s 224.0.0.0/8 -d 0/0 -j $ALL_STOP
         if [ "$LOG_DROP" == "1" ]; then
-	 $IPT -A MCAST -s 0/0 -d 224.0.0.0/8 -m limit --limit=$LOG_RATE/minute -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix "** MCAST ** "
+	 $IPT $IPT_FLAGS -A MCAST -s 0/0 -d 224.0.0.0/8 -m limit --limit=$LOG_RATE/minute -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix "** MCAST ** "
 	fi
-	$IPT -A MCAST -s 0/0 -d 224.0.0.0/8 -j $ALL_STOP
-	$IPT -A INPUT -j MCAST
-	$IPT -A OUTPUT -j MCAST
+	$IPT $IPT_FLAGS -A MCAST -s 0/0 -d 224.0.0.0/8 -j $ALL_STOP
+	$IPT $IPT_FLAGS -A INPUT -j MCAST
+	$IPT $IPT_FLAGS -A OUTPUT -j MCAST
 fi
 
 if [ ! "$BLK_P2P_PORTS" == "" ]; then
         eout "{blk_p2p} set active BLK_P2P"
         # Drop traffic to/from common p2p networks
         # winmx,napster,bittorrent,gnutella,edonkey,kazaa,morpheus
-        $IPT -N P2P
+        $IPT $IPT_FLAGS -N P2P
         for i in `echo $BLK_P2P_PORTS | tr ',' ' '`; do
                 MVAL=`echo $i | grep "_"`
                 PORT=$i
@@ -285,21 +285,21 @@ if [ ! "$BLK_P2P_PORTS" == "" ]; then
                         eout "{blk_p2p} deny all to/from tcp port $i"
                         eout "{blk_p2p} deny all to/from udp port $i"
                         if [ "$LOG_DROP" == "1" ]; then
-                         $IPT -A P2P  -p tcp -s 0/0 -d 0/0 --sport 1024:65534 --dport $PORT -m limit --limit=$LOG_RATE/minute -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix "** P2P ** "
+                         $IPT $IPT_FLAGS -A P2P  -p tcp -s 0/0 -d 0/0 --sport 1024:65534 --dport $PORT -m limit --limit=$LOG_RATE/minute -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix "** P2P ** "
                         fi
-                        $IPT -A P2P  -p tcp -s 0/0 -d 0/0 --dport $PORT -j REJECT
+                        $IPT $IPT_FLAGS -A P2P  -p tcp -s 0/0 -d 0/0 --dport $PORT -j REJECT
                         if [ "$LOG_DROP" == "1" ]; then
-                         $IPT -A P2P  -p tcp -s 0/0 -d 0/0 --dport 1024:65534 --sport $PORT -m limit --limit=$LOG_RATE/minute -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix "** P2P ** "
+                         $IPT $IPT_FLAGS -A P2P  -p tcp -s 0/0 -d 0/0 --dport 1024:65534 --sport $PORT -m limit --limit=$LOG_RATE/minute -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix "** P2P ** "
                         fi
-                        $IPT -A P2P  -p tcp -s 0/0 -d 0/0 --dport 1024:65534 --sport $PORT -j REJECT
+                        $IPT $IPT_FLAGS -A P2P  -p tcp -s 0/0 -d 0/0 --dport 1024:65534 --sport $PORT -j REJECT
                         if [ "$LOG_DROP" == "1" ]; then
-                         $IPT -A P2P  -p udp -s 0/0 -d 0/0 --sport 1024:65534 --dport $PORT -m limit --limit=$LOG_RATE/minute -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix "** P2P ** "
+                         $IPT $IPT_FLAGS -A P2P  -p udp -s 0/0 -d 0/0 --sport 1024:65534 --dport $PORT -m limit --limit=$LOG_RATE/minute -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix "** P2P ** "
                         fi
-                        $IPT -A P2P  -p udp -s 0/0 -d 0/0 --sport 1024:65534 --dport $PORT -j REJECT
+                        $IPT $IPT_FLAGS -A P2P  -p udp -s 0/0 -d 0/0 --sport 1024:65534 --dport $PORT -j REJECT
                         if [ "$LOG_DROP" == "1" ]; then
-                         $IPT -A P2P  -p udp -s 0/0 -d 0/0 --dport 1024:65534 --sport $PORT -m limit --limit=$LOG_RATE/minute -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix "** P2P ** "
+                         $IPT $IPT_FLAGS -A P2P  -p udp -s 0/0 -d 0/0 --dport 1024:65534 --sport $PORT -m limit --limit=$LOG_RATE/minute -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix "** P2P ** "
                         fi
-                        $IPT -A P2P  -p udp -s 0/0 -d 0/0 --dport 1024:65534 --sport $PORT -j REJECT
+                        $IPT $IPT_FLAGS -A P2P  -p udp -s 0/0 -d 0/0 --dport 1024:65534 --sport $PORT -j REJECT
                 else
                         PORT_BEG=`echo $i | tr '_' ' ' | awk '{print$1}'`
                         PORT_END=`echo $i | tr '_' ' ' | awk '{print$2}'`
@@ -307,31 +307,31 @@ if [ ! "$BLK_P2P_PORTS" == "" ]; then
                         eout "{blk_p2p} deny all to/from tcp port $PORTST"
                         eout "{blk_p2p} deny all to/from udp port $PORTST"
                         if [ "$LOG_DROP" == "1" ]; then
-                         $IPT -A P2P  -p tcp -s 0/0 -d 0/0 --sport 1024:65534 --dport $PORTST -m limit --limit=$LOG_RATE/minute -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix "** P2P ** "
+                         $IPT $IPT_FLAGS -A P2P  -p tcp -s 0/0 -d 0/0 --sport 1024:65534 --dport $PORTST -m limit --limit=$LOG_RATE/minute -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix "** P2P ** "
                         fi
-                        $IPT -A P2P  -p tcp -s 0/0 -d 0/0 --sport 1024:65534 --dport $PORTST -j REJECT
+                        $IPT $IPT_FLAGS -A P2P  -p tcp -s 0/0 -d 0/0 --sport 1024:65534 --dport $PORTST -j REJECT
                         if [ "$LOG_DROP" == "1" ]; then
-                         $IPT -A P2P  -p tcp -s 0/0 -d 0/0 --dport 1024:65534 --sport $PORTST -m limit --limit=$LOG_RATE/minute -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix "** P2P ** "
+                         $IPT $IPT_FLAGS -A P2P  -p tcp -s 0/0 -d 0/0 --dport 1024:65534 --sport $PORTST -m limit --limit=$LOG_RATE/minute -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix "** P2P ** "
                         fi
-                        $IPT -A P2P  -p tcp -s 0/0 -d 0/0 --dport 1024:65534 --sport $PORTST -j REJECT
+                        $IPT $IPT_FLAGS -A P2P  -p tcp -s 0/0 -d 0/0 --dport 1024:65534 --sport $PORTST -j REJECT
                         if [ "$LOG_DROP" == "1" ]; then
-                         $IPT -A P2P  -p udp -s 0/0 -d 0/0 --sport 1024:65534 --dport $PORTST -m limit --limit=$LOG_RATE/minute -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix "** P2P ** "
+                         $IPT $IPT_FLAGS -A P2P  -p udp -s 0/0 -d 0/0 --sport 1024:65534 --dport $PORTST -m limit --limit=$LOG_RATE/minute -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix "** P2P ** "
                         fi
-                        $IPT -A P2P  -p udp -s 0/0 -d 0/0 --sport 1024:65534 --dport $PORTST -j REJECT
+                        $IPT $IPT_FLAGS -A P2P  -p udp -s 0/0 -d 0/0 --sport 1024:65534 --dport $PORTST -j REJECT
                         if [ "$LOG_DROP" == "1" ]; then
-                         $IPT -A P2P  -p udp -s 0/0 -d 0/0 --dport 1024:65534 --sport $PORTST -m limit --limit=$LOG_RATE/minute -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix "** P2P ** "
+                         $IPT $IPT_FLAGS -A P2P  -p udp -s 0/0 -d 0/0 --dport 1024:65534 --sport $PORTST -m limit --limit=$LOG_RATE/minute -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix "** P2P ** "
                         fi
-                        $IPT -A P2P  -p udp -s 0/0 -d 0/0 --dport 1024:65534 --sport $PORTST -j REJECT
+                        $IPT $IPT_FLAGS -A P2P  -p udp -s 0/0 -d 0/0 --dport 1024:65534 --sport $PORTST -j REJECT
                 fi
         done
-        $IPT -A INPUT -j P2P
-        $IPT -A OUTPUT -j P2P
+        $IPT $IPT_FLAGS -A INPUT -j P2P
+        $IPT $IPT_FLAGS -A OUTPUT -j P2P
 fi
 
 if [ "$BLK_TCP_SACK_PANIC" == "1" ] && [ ! "$SYSCTL_TCP_NOSACK" == "1" ]; then
 	eout "{blk_tcp_sack_panic} applying mitigation for TCP SACK Panic CVE-2019-11477, CVE-2019-11478, CVE-2019-11479 https://access.redhat.com/security/vulnerabilities/tcpsack"
 	eout "{blk_tcp_sack_panic} deny inbound tcp-flags SYN with MSS size 1 to 500 bytes "
-	$IPT -I INPUT -p tcp --tcp-flags SYN SYN -m tcpmss --mss 1:500 -j $TCP_STOP
+	$IPT $IPT_FLAGS -I INPUT -p tcp --tcp-flags SYN SYN -m tcpmss --mss 1:500 -j $TCP_STOP
 	if [ "$USE_IPV6" == "1" ]; then
 		$IP6T -I INPUT -p tcp --tcp-flags SYN SYN -m tcpmss --mss 1:500 -j $TCP_STOP
 	fi

--- a/files/conf.apf
+++ b/files/conf.apf
@@ -561,6 +561,11 @@ LOG_RATE="30"
 # sends outputs to this file
 LOG_APF="/var/log/apf_log"
 
+# Adds -w flag to iptables to enable locking support. This is only available
+# on iptables >= 1.4.20, but if supported you probably want this.
+IPT_LOCK_SUPPORT="0"
+IPT_LOCK_TIMEOUT="3"
+
 ##
 # [Import misc. conf]
 ##

--- a/files/firewall
+++ b/files/firewall
@@ -73,8 +73,8 @@ tosroute PREROUTING
 . $PRERT
 
 # Allow all traffic on the loopback interface
-$IPT -A INPUT -i lo -s 0/0 -d 0/0 -j ACCEPT
-$IPT -A OUTPUT -o lo -s 0/0 -d 0/0 -j ACCEPT
+$IPT $IPT_FLAGS -A INPUT -i lo -s 0/0 -d 0/0 -j ACCEPT
+$IPT $IPT_FLAGS -A OUTPUT -o lo -s 0/0 -d 0/0 -j ACCEPT
 if [ "$USE_IPV6" == "1" ]; then
 	$IP6T -A INPUT -i lo -s 0/0 -d 0/0 -j ACCEPT
 	$IP6T -A OUTPUT -o lo -s 0/0 -d 0/0 -j ACCEPT
@@ -89,23 +89,23 @@ if [ ! "$IFACE_TRUSTED" == "" ]; then
         eout "{glob} unable to verify status of interface $i; assuming untrusted"
  else
         eout "{glob} allow all to/from trusted interface $i"
-        $IPT -A INPUT -i $i -s 0/0 -d 0/0 -j ACCEPT
-        $IPT -A OUTPUT -o $i -s 0/0 -d 0/0 -j ACCEPT
+        $IPT $IPT_FLAGS -A INPUT -i $i -s 0/0 -d 0/0 -j ACCEPT
+        $IPT $IPT_FLAGS -A OUTPUT -o $i -s 0/0 -d 0/0 -j ACCEPT
  fi
  done
 fi
 
 # Create TCP RESET & UDP PROHIBIT chains
-$IPT -N RESET
-$IPT -A RESET -p tcp -j REJECT --reject-with tcp-reset
-$IPT -N PROHIBIT
-$IPT -A PROHIBIT -j REJECT --reject-with icmp-host-prohibited
+$IPT $IPT_FLAGS -N RESET
+$IPT $IPT_FLAGS -A RESET -p tcp -j REJECT --reject-with tcp-reset
+$IPT $IPT_FLAGS -N PROHIBIT
+$IPT $IPT_FLAGS -A PROHIBIT -j REJECT --reject-with icmp-host-prohibited
 
 # Load our SYSCTL rules
 . $INSTALL_PATH/sysctl.rules >> /dev/null 2>&1
 
 # Fix MTU/MSS Problems
-$IPT -A OUTPUT -p tcp --tcp-flags SYN,RST SYN -j TCPMSS --clamp-mss-to-pmtu
+$IPT $IPT_FLAGS -A OUTPUT -p tcp --tcp-flags SYN,RST SYN -j TCPMSS --clamp-mss-to-pmtu
 
 # Block common nonroutable IP networks
 if [ "$BLK_MCATNET" = "1" ]; then
@@ -122,21 +122,21 @@ if [ "$BLK_RESNET" = "1" ]; then
 fi
 
 # Create (glob)trust system chains
-$IPT -N TALLOW
-$IPT -N TDENY
-$IPT -N TGALLOW
-$IPT -N TGDENY
-$IPT -N REFRESH_TEMP
-$IPT -A INPUT -j REFRESH_TEMP
-$IPT -A OUTPUT -j REFRESH_TEMP
-$IPT -A INPUT -j TALLOW
-$IPT -A OUTPUT -j TALLOW
-$IPT -A INPUT -j TGALLOW
-$IPT -A OUTPUT -j TGALLOW
-$IPT -A INPUT -j TDENY
-$IPT -A OUTPUT -j TDENY
-$IPT -A INPUT -j TGDENY
-$IPT -A OUTPUT -j TGDENY
+$IPT $IPT_FLAGS -N TALLOW
+$IPT $IPT_FLAGS -N TDENY
+$IPT $IPT_FLAGS -N TGALLOW
+$IPT $IPT_FLAGS -N TGDENY
+$IPT $IPT_FLAGS -N REFRESH_TEMP
+$IPT $IPT_FLAGS -A INPUT -j REFRESH_TEMP
+$IPT $IPT_FLAGS -A OUTPUT -j REFRESH_TEMP
+$IPT $IPT_FLAGS -A INPUT -j TALLOW
+$IPT $IPT_FLAGS -A OUTPUT -j TALLOW
+$IPT $IPT_FLAGS -A INPUT -j TGALLOW
+$IPT $IPT_FLAGS -A OUTPUT -j TGALLOW
+$IPT $IPT_FLAGS -A INPUT -j TDENY
+$IPT $IPT_FLAGS -A OUTPUT -j TDENY
+$IPT $IPT_FLAGS -A INPUT -j TGDENY
+$IPT $IPT_FLAGS -A OUTPUT -j TGDENY
 
 # Load our Blocked Traffic rules
 . $INSTALL_PATH/bt.rules
@@ -164,9 +164,9 @@ if [ "$RAB" == "1" ]; then
  fi
 
  if [ "$LOG_DROP" == "1" ] || [ "$RAB_LOG_TRIP" == "1" ]; then
-	$IPT -A INPUT -p all -m recent --rcheck --hitcount $RAB_HITCOUNT --seconds $RAB_TIMER -m limit --limit=$LOG_RATE/minute -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix="** RABTRIP ** "
+	$IPT $IPT_FLAGS -A INPUT -p all -m recent --rcheck --hitcount $RAB_HITCOUNT --seconds $RAB_TIMER -m limit --limit=$LOG_RATE/minute -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix="** RABTRIP ** "
  fi
- $IPT -A INPUT -p all -m recent $RAB_TRIP_FLAGS --hitcount $RAB_HITCOUNT --seconds $RAB_TIMER -j $ALL_STOP
+ $IPT $IPT_FLAGS -A INPUT -p all -m recent $RAB_TRIP_FLAGS --hitcount $RAB_HITCOUNT --seconds $RAB_TIMER -j $ALL_STOP
 
  # RAB portscan rules
  if [ ! "$RAB_PSCAN_LEVEL" == "0" ] || [ ! "$RAB_PSCAN_LEVEL" == "" ]; then
@@ -182,22 +182,22 @@ if [ "$RAB" == "1" ]; then
   RAB_PSCAN_PORTS="$RAB_PSCAN_LEVEL_3"
   esac
   eout "{rab} RAB_PSCAN monitored ports $RAB_PSCAN_PORTS"
-  $IPT -N RABPSCAN
+  $IPT $IPT_FLAGS -N RABPSCAN
   LDNS=`cat /etc/resolv.conf  | grep -v "#" | grep -w nameserver | awk '{print$2}' | grep -v 127.0.0.1`
   if [ "$LDNS" ]; then
 	for i in `echo $LDNS`; do
-		$IPT -I RABPSCAN -s $i -j RETURN
+		$IPT $IPT_FLAGS -I RABPSCAN -s $i -j RETURN
 	done
   fi
   for i in `echo $RAB_PSCAN_PORTS | tr ',' ' '`; do
    if [ "$LOG_DROP" == "1" ] || [ "$RAB_LOG_HIT" == "1" ]; then
-	   $IPT -A RABPSCAN -p tcp --dport $i -m limit --limit=$LOG_RATE/minute -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix="** RABHIT ** "
-	   $IPT -A RABPSCAN -p udp --dport $i -m limit --limit=$LOG_RATE/minute -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix="** RABHIT ** "
+	   $IPT $IPT_FLAGS -A RABPSCAN -p tcp --dport $i -m limit --limit=$LOG_RATE/minute -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix="** RABHIT ** "
+	   $IPT $IPT_FLAGS -A RABPSCAN -p udp --dport $i -m limit --limit=$LOG_RATE/minute -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix="** RABHIT ** "
    fi
-   $IPT -A RABPSCAN -p tcp --dport $i -m recent --set -j $TCP_STOP
-   $IPT -A RABPSCAN -p udp --dport $i -m recent --set -j $UDP_STOP
+   $IPT $IPT_FLAGS -A RABPSCAN -p tcp --dport $i -m recent --set -j $TCP_STOP
+   $IPT $IPT_FLAGS -A RABPSCAN -p udp --dport $i -m recent --set -j $UDP_STOP
   done
-  $IPT -A INPUT -j RABPSCAN
+  $IPT $IPT_FLAGS -A INPUT -j RABPSCAN
  fi
 fi
 
@@ -223,11 +223,11 @@ fi
 . $INSTALL_PATH/main.rules
 
 # Drop NEW tcp connections after this point
-$IPT -A INPUT  -p tcp ! --syn -m state --state NEW -j $ALL_STOP
-$IPT -A INPUT  -p tcp -m state --state ESTABLISHED,RELATED -j ACCEPT
-$IPT -A INPUT  -p udp -m state --state ESTABLISHED,RELATED -j ACCEPT
-$IPT -A OUTPUT  -p tcp --dport 1024:65535 -m state --state ESTABLISHED,RELATED -j ACCEPT
-$IPT -A OUTPUT  -p udp --dport 1024:65535 -m state --state ESTABLISHED,RELATED -j ACCEPT
+$IPT $IPT_FLAGS -A INPUT  -p tcp ! --syn -m state --state NEW -j $ALL_STOP
+$IPT $IPT_FLAGS -A INPUT  -p tcp -m state --state ESTABLISHED,RELATED -j ACCEPT
+$IPT $IPT_FLAGS -A INPUT  -p udp -m state --state ESTABLISHED,RELATED -j ACCEPT
+$IPT $IPT_FLAGS -A OUTPUT  -p tcp --dport 1024:65535 -m state --state ESTABLISHED,RELATED -j ACCEPT
+$IPT $IPT_FLAGS -A OUTPUT  -p udp --dport 1024:65535 -m state --state ESTABLISHED,RELATED -j ACCEPT
 
 # DNS
 if [ -f "/etc/resolv.conf" ] && [ "$RESV_DNS" == "1" ]; then
@@ -235,61 +235,61 @@ LDNS=`cat /etc/resolv.conf  | grep -v "#" | grep -w nameserver | awk '{print$2}'
   if [ ! "$LDNS" == "" ]; then
         for i in `echo $LDNS`; do
         eout "{glob} resolv dns discovery for $i"
-        $IPT -A INPUT -p udp -s $i --sport 53 --dport 1023:65535 -j ACCEPT
-        $IPT -A INPUT -p tcp -s $i --sport 53 --dport 1023:65535 -j ACCEPT
-        $IPT -A OUTPUT -p udp -d $i --dport 53 --sport 1023:65535 -j ACCEPT
-        $IPT -A OUTPUT -p tcp -d $i --dport 53 --sport 1023:65535 -j ACCEPT
+        $IPT $IPT_FLAGS -A INPUT -p udp -s $i --sport 53 --dport 1023:65535 -j ACCEPT
+        $IPT $IPT_FLAGS -A INPUT -p tcp -s $i --sport 53 --dport 1023:65535 -j ACCEPT
+        $IPT $IPT_FLAGS -A OUTPUT -p udp -d $i --dport 53 --sport 1023:65535 -j ACCEPT
+        $IPT $IPT_FLAGS -A OUTPUT -p tcp -d $i --dport 53 --sport 1023:65535 -j ACCEPT
         if [ "$RESV_DNS_DROP" == "1" ]; then
-                $IPT -A OUTPUT -p udp -d $i --dport 53 --sport 1023:65535 -j ACCEPT
-                $IPT -A OUTPUT -p tcp -d $i --dport 53 --sport 1023:65535 -j ACCEPT
+                $IPT $IPT_FLAGS -A OUTPUT -p udp -d $i --dport 53 --sport 1023:65535 -j ACCEPT
+                $IPT $IPT_FLAGS -A OUTPUT -p tcp -d $i --dport 53 --sport 1023:65535 -j ACCEPT
         fi
         done
         if [ "$RESV_DNS_DROP" == "1" ]; then
-                $IPT -A INPUT  -p tcp -s 0/0 --sport 53 --dport 1023:65535 -j $ALL_STOP
-                $IPT -A INPUT  -p udp -s 0/0 --sport 53 --dport 1023:65535 -j $ALL_STOP
+                $IPT $IPT_FLAGS -A INPUT  -p tcp -s 0/0 --sport 53 --dport 1023:65535 -j $ALL_STOP
+                $IPT $IPT_FLAGS -A INPUT  -p udp -s 0/0 --sport 53 --dport 1023:65535 -j $ALL_STOP
         fi
   fi
 else
-        $IPT -A INPUT  -p udp --sport 53 --dport 1023:65535 -j ACCEPT
-        $IPT -A INPUT  -p tcp --sport 53 --dport 1023:65535 -j ACCEPT
-        $IPT -A OUTPUT -p udp --dport 53 --sport 1023:65535 -j ACCEPT
-        $IPT -A OUTPUT -p tcp --dport 53 --sport 1023:65535 -j ACCEPT
+        $IPT $IPT_FLAGS -A INPUT  -p udp --sport 53 --dport 1023:65535 -j ACCEPT
+        $IPT $IPT_FLAGS -A INPUT  -p tcp --sport 53 --dport 1023:65535 -j ACCEPT
+        $IPT $IPT_FLAGS -A OUTPUT -p udp --dport 53 --sport 1023:65535 -j ACCEPT
+        $IPT $IPT_FLAGS -A OUTPUT -p tcp --dport 53 --sport 1023:65535 -j ACCEPT
 fi
 
 # FTP
 if [ "$HELPER_FTP" == "1" ]; then
-$IPT -A INPUT  -p tcp --sport 1023:65535 --dport $HELPER_FTP_PORT -m state --state RELATED,ESTABLISHED -j ACCEPT
-$IPT -A INPUT  -p tcp -m multiport --dport $HELPER_FTP_PORT,$HELPER_FTP_DATA -m state --state ESTABLISHED,RELATED -j ACCEPT
-$IPT -A INPUT  -p udp -m multiport --dport $HELPER_FTP_PORT,$HELPER_FTP_DATA -m state --state ESTABLISHED,RELATED -j ACCEPT
-$IPT -A OUTPUT  -p tcp --dport 1023:65535 --sport $HELPER_FTP_PORT -m state --state RELATED,ESTABLISHED -j ACCEPT
-$IPT -A OUTPUT  -p tcp -m multiport --dport $HELPER_FTP_PORT,$HELPER_FTP_DATA -m state --state ESTABLISHED,RELATED -j ACCEPT
-$IPT -A OUTPUT  -p udp -m multiport --dport $HELPER_FTP_PORT,$HELPER_FTP_DATA -m state --state ESTABLISHED,RELATED -j ACCEPT
+$IPT $IPT_FLAGS -A INPUT  -p tcp --sport 1023:65535 --dport $HELPER_FTP_PORT -m state --state RELATED,ESTABLISHED -j ACCEPT
+$IPT $IPT_FLAGS -A INPUT  -p tcp -m multiport --dport $HELPER_FTP_PORT,$HELPER_FTP_DATA -m state --state ESTABLISHED,RELATED -j ACCEPT
+$IPT $IPT_FLAGS -A INPUT  -p udp -m multiport --dport $HELPER_FTP_PORT,$HELPER_FTP_DATA -m state --state ESTABLISHED,RELATED -j ACCEPT
+$IPT $IPT_FLAGS -A OUTPUT  -p tcp --dport 1023:65535 --sport $HELPER_FTP_PORT -m state --state RELATED,ESTABLISHED -j ACCEPT
+$IPT $IPT_FLAGS -A OUTPUT  -p tcp -m multiport --dport $HELPER_FTP_PORT,$HELPER_FTP_DATA -m state --state ESTABLISHED,RELATED -j ACCEPT
+$IPT $IPT_FLAGS -A OUTPUT  -p udp -m multiport --dport $HELPER_FTP_PORT,$HELPER_FTP_DATA -m state --state ESTABLISHED,RELATED -j ACCEPT
 fi
 
 # SSH
 if [ "$HELPER_SSH" == "1" ]; then
-	$IPT -A INPUT  -p tcp --sport $HELPER_SSH_PORT --dport 513:65535 -m state --state ESTABLISHED,RELATED -j ACCEPT
-	$IPT -A INPUT  -p tcp --sport 1024:65535 --dport $HELPER_SSH_PORT --syn -m state --state ESTABLISHED,RELATED -j ACCEPT
-	$IPT -A INPUT  -p udp --dport $HELPER_SSH_PORT -m state --state ESTABLISHED -j ACCEPT
+	$IPT $IPT_FLAGS -A INPUT  -p tcp --sport $HELPER_SSH_PORT --dport 513:65535 -m state --state ESTABLISHED,RELATED -j ACCEPT
+	$IPT $IPT_FLAGS -A INPUT  -p tcp --sport 1024:65535 --dport $HELPER_SSH_PORT --syn -m state --state ESTABLISHED,RELATED -j ACCEPT
+	$IPT $IPT_FLAGS -A INPUT  -p udp --dport $HELPER_SSH_PORT -m state --state ESTABLISHED -j ACCEPT
 fi
 
 # Traceroute
 if [ "$TCR_PASS" == "1" ]; then
-	$IPT -A INPUT  -p udp -m state --state NEW --dport $TCR_PORTS -j ACCEPT
-        $IPT -A OUTPUT  -p udp -m state --state NEW --dport $TCR_PORTS -j ACCEPT
+	$IPT $IPT_FLAGS -A INPUT  -p udp -m state --state NEW --dport $TCR_PORTS -j ACCEPT
+        $IPT $IPT_FLAGS -A OUTPUT  -p udp -m state --state NEW --dport $TCR_PORTS -j ACCEPT
 fi
 
 
 if [ "$LOG_DROP" == "1" ]; then
 # Default TCP/UDP INPUT log chain
-         $IPT -A INPUT -p tcp -m limit --limit $LOG_RATE/minute  -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix "** IN_TCP DROP ** "
-         $IPT -A INPUT -p udp -m limit --limit $LOG_RATE/minute  -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix "** IN_UDP DROP ** "
+         $IPT $IPT_FLAGS -A INPUT -p tcp -m limit --limit $LOG_RATE/minute  -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix "** IN_TCP DROP ** "
+         $IPT $IPT_FLAGS -A INPUT -p udp -m limit --limit $LOG_RATE/minute  -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix "** IN_UDP DROP ** "
 fi
 
 if [ "$LOG_DROP" == "1" ] && [ "$EGF" == "1" ]; then
 # Default TCP/UDP OUTPUT log chain
-         $IPT -A OUTPUT -p tcp -m limit --limit $LOG_RATE/minute  -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix "** OUT_TCP DROP ** "
-         $IPT -A OUTPUT -p udp -m limit --limit $LOG_RATE/minute  -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix "** OUT_UDP DROP ** "
+         $IPT $IPT_FLAGS -A OUTPUT -p tcp -m limit --limit $LOG_RATE/minute  -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix "** OUT_TCP DROP ** "
+         $IPT $IPT_FLAGS -A OUTPUT -p udp -m limit --limit $LOG_RATE/minute  -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix "** OUT_UDP DROP ** "
 fi
 
 
@@ -305,17 +305,17 @@ tosroute POSTROUTING
 
 # Default Output Policies
 if [ ! "$EGF" == "1" ] || [ "$EGF" == "" ]; then
-        $IPT -A OUTPUT -j ACCEPT
+        $IPT $IPT_FLAGS -A OUTPUT -j ACCEPT
         eout "{glob} default (egress) output accept"
 elif [ "$EGF" == "1" ]; then
-	$IPT -A OUTPUT -p tcp -j $TCP_STOP
-	$IPT -A OUTPUT -p udp -j $UDP_STOP
-        $IPT -A OUTPUT -p all -j $ALL_STOP
+	$IPT $IPT_FLAGS -A OUTPUT -p tcp -j $TCP_STOP
+	$IPT $IPT_FLAGS -A OUTPUT -p udp -j $UDP_STOP
+        $IPT $IPT_FLAGS -A OUTPUT -p all -j $ALL_STOP
         eout "{glob} default (egress) output drop"
 fi
 
 # Default Input Policies
 eout "{glob} default (ingress) input drop"
-$IPT -A INPUT -p tcp -j $TCP_STOP
-$IPT -A INPUT -p udp -j $UDP_STOP
-$IPT -A INPUT -p all -j $ALL_STOP
+$IPT $IPT_FLAGS -A INPUT -p tcp -j $TCP_STOP
+$IPT $IPT_FLAGS -A INPUT -p udp -j $UDP_STOP
+$IPT $IPT_FLAGS -A INPUT -p all -j $ALL_STOP

--- a/files/internals/cports.common
+++ b/files/internals/cports.common
@@ -4,13 +4,13 @@ PROTO="tcp"
 for i in `echo $IG_TCP_CPORTS`; do
         if [ "$(echo $i | grep "_")" == "" ]; then
          if [ ! "$i" == "" ]; then
-                $IPT -A INPUT -p $PROTO  -s 0/0 -d $VNET --dport $i -j ACCEPT
+                $IPT $IPT_FLAGS -A INPUT -p $PROTO  -s 0/0 -d $VNET --dport $i -j ACCEPT
                 eout "{glob} opening inbound $PROTO port $i on $VNET"
          fi
         else
                 i=`echo $i | tr '_' ':'`
                 if [ ! "$i" == "" ]; then
-                        $IPT -A INPUT -p $PROTO  -s 0/0 -d $VNET --dport $i -j ACCEPT
+                        $IPT $IPT_FLAGS -A INPUT -p $PROTO  -s 0/0 -d $VNET --dport $i -j ACCEPT
                         eout "{glob} opening inbound $PROTO port $i on $VNET"
                 fi
         fi
@@ -23,13 +23,13 @@ PROTO="udp"
 for i in `echo $IG_UDP_CPORTS`; do
         if [ "$(echo $i | grep "_")" == "" ]; then
          if [ ! "$i" == "" ]; then
-                $IPT -A INPUT -p $PROTO  -s 0/0 -d $VNET --dport $i -j ACCEPT
+                $IPT $IPT_FLAGS -A INPUT -p $PROTO  -s 0/0 -d $VNET --dport $i -j ACCEPT
                 eout "{glob} opening inbound $PROTO port $i on $VNET"
          fi
         else
                 i=`echo $i | tr '_' ':'`
                 if [ ! "$i" == "" ]; then
-                        $IPT -A INPUT -p $PROTO  -s 0/0 -d $VNET --dport $i -j ACCEPT
+                        $IPT $IPT_FLAGS -A INPUT -p $PROTO  -s 0/0 -d $VNET --dport $i -j ACCEPT
                         eout "{glob} opening inbound $PROTO port $i on $VNET"
                 fi
         fi
@@ -43,13 +43,13 @@ PROTO="tcp"
 for i in `echo $EG_TCP_CPORTS`; do
         if [ "$(echo $i | grep "_")" == "" ]; then
          if [ ! "$i" == "" ]; then
-                $IPT -A OUTPUT -p $PROTO  -s $VNET --dport $i -j ACCEPT
+                $IPT $IPT_FLAGS -A OUTPUT -p $PROTO  -s $VNET --dport $i -j ACCEPT
                 eout "{glob} opening outbound $PROTO port $i on $VNET"
          fi
         else
                 i=`echo $i | tr '_' ':'`
                 if [ ! "$i" == "" ]; then
-                        $IPT -A OUTPUT -p $PROTO  -s $VNET --dport $i -j ACCEPT
+                        $IPT $IPT_FLAGS -A OUTPUT -p $PROTO  -s $VNET --dport $i -j ACCEPT
                         eout "{glob} opening outbound $PROTO port $i on $VNET"
                 fi
         fi
@@ -64,13 +64,13 @@ PROTO="udp"
 for i in `echo $EG_UDP_CPORTS`; do
         if [ "$(echo $i | grep "_")" == "" ]; then
          if [ ! "$i" == "" ]; then
-                $IPT -A OUTPUT -p $PROTO  -s $VNET --dport $i -j ACCEPT
+                $IPT $IPT_FLAGS -A OUTPUT -p $PROTO  -s $VNET --dport $i -j ACCEPT
                 eout "{glob} opening outbound $PROTO port $i on $VNET"
          fi
         else
                 i=`echo $i | tr '_' ':'`
                 if [ ! "$i" == "" ]; then
-                        $IPT -A OUTPUT -p $PROTO  -s $VNET --dport $i -j ACCEPT
+                        $IPT $IPT_FLAGS -A OUTPUT -p $PROTO  -s $VNET --dport $i -j ACCEPT
                         eout "{glob} opening outbound $PROTO port $i on $VNET"
                 fi
         fi
@@ -93,10 +93,10 @@ IG_ICMP_TYPES=`echo $IG_ICMP_TYPES | tr ',' ' '`
          if [ ! "$i" == "" ]; then
                 i=`echo $i | tr '[:upper:]' '[:lower:]'`
                 if [ "$i" == "all" ]; then
-                  $IPT -A INPUT -p icmp -d $VNET  -s 0/0 $ICMP_EARGS -j ACCEPT
+                  $IPT $IPT_FLAGS -A INPUT -p icmp -d $VNET  -s 0/0 $ICMP_EARGS -j ACCEPT
                   eout "{glob} opening inbound $PROTO all on $VNET"
                 else
-                  $IPT -A INPUT -p icmp --icmp-type $i -d $VNET  -s 0/0 $ICMP_EARGS -j ACCEPT
+                  $IPT $IPT_FLAGS -A INPUT -p icmp --icmp-type $i -d $VNET  -s 0/0 $ICMP_EARGS -j ACCEPT
                   eout "{glob} opening inbound $PROTO type $i on $VNET"
                 fi
 	 fi
@@ -119,10 +119,10 @@ EG_ICMP_TYPES=`echo $EG_ICMP_TYPES | tr ',' ' '`
          if [ ! "$i" == "" ]; then
 		i=`echo $i | tr '[:upper:]' '[:lower:]'`
 		if [ "$i" == "all" ]; then
-                  $IPT -A OUTPUT -p icmp  -s $VNET -d 0/0 $ICMP_EARGS  -j ACCEPT
+                  $IPT $IPT_FLAGS -A OUTPUT -p icmp  -s $VNET -d 0/0 $ICMP_EARGS  -j ACCEPT
                   eout "{glob} opening outbound $PROTO all on $VNET"
 		else
-                  $IPT -A OUTPUT -p icmp --icmp-type $i  -s $VNET -d 0/0 $ICMP_EARGS -j ACCEPT
+                  $IPT $IPT_FLAGS -A OUTPUT -p icmp --icmp-type $i  -s $VNET -d 0/0 $ICMP_EARGS -j ACCEPT
                   eout "{glob} opening outbound $PROTO type $i on $VNET"
 		fi
          fi
@@ -140,13 +140,13 @@ port=`echo $i | tr ':' ' ' | awk '{print$2}'`
 
         if [ "$(echo $port | grep "_")" == "" ]; then
          if [ ! "$port" == "" ]; then
-                $IPT -A OUTPUT -p $PROTO  -s $VNET --dport $port --match owner --uid-owner $uid -j ACCEPT
+                $IPT $IPT_FLAGS -A OUTPUT -p $PROTO  -s $VNET --dport $port --match owner --uid-owner $uid -j ACCEPT
                 eout "{glob} opening outbound $PROTO port $port for uid $uid from $VNET"
          fi
         else
                 i=`echo $port | tr '_' ':'`
                 if [ ! "$i" == "" ]; then
-                $IPT -A OUTPUT -p $PROTO  -s $VNET --dport $i --match owner --uid-owner $uid -j ACCEPT
+                $IPT $IPT_FLAGS -A OUTPUT -p $PROTO  -s $VNET --dport $i --match owner --uid-owner $uid -j ACCEPT
                 eout "{glob} opening outbound $PROTO port $i for uid $uid from $VNET"
                 fi
         fi
@@ -164,13 +164,13 @@ port=`echo $i | tr ':' ' ' | awk '{print$2}'`
 
         if [ "$(echo $port | grep "_")" == "" ]; then
          if [ ! "$port" == "" ]; then
-                $IPT -A OUTPUT -p $PROTO  -s $VNET --dport $port --match owner --uid-owner $uid -j ACCEPT
+                $IPT $IPT_FLAGS -A OUTPUT -p $PROTO  -s $VNET --dport $port --match owner --uid-owner $uid -j ACCEPT
                 eout "{glob} opening outbound $PROTO port $port for uid $uid from $VNET"
          fi
         else
                 i=`echo $port | tr '_' ':'`
                 if [ ! "$i" == "" ]; then
-                $IPT -A OUTPUT -p $PROTO  -s $VNET --dport $i --match owner --uid-owner $uid -j ACCEPT
+                $IPT $IPT_FLAGS -A OUTPUT -p $PROTO  -s $VNET --dport $i --match owner --uid-owner $uid -j ACCEPT
                 eout "{glob} opening outbound $PROTO port $i for uid $uid from $VNET"
                 fi
         fi
@@ -180,14 +180,14 @@ fi
 
 if [ "$EGF" == "1" ]; then
  if [ "$EG_DROP_CMD" == "1" ]; then
-		$IPT -N DEG
+		$IPT $IPT_FLAGS -N DEG
 	for i in `echo $EG_DROP_CMD | tr ',' ' '`; do
 		si=`echo $i | cut -c 1-6`		
 		if [ "LOG_DROP" == "1" ]; then 
-		  $IPT -A DEG -m limit --limit=$LOG_RATE/minute -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix="** DEG_$si ** "
+		  $IPT $IPT_FLAGS -A DEG -m limit --limit=$LOG_RATE/minute -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix="** DEG_$si ** "
 		fi
-		$IPT -A DEG -s 0/0 -d 0/0 -m owner --cmd-owner=$i -j $ALL_STOP
+		$IPT $IPT_FLAGS -A DEG -s 0/0 -d 0/0 -m owner --cmd-owner=$i -j $ALL_STOP
 	done
-		  $IPT -A OUTPUT -j DEG
+		  $IPT $IPT_FLAGS -A OUTPUT -j DEG
  fi
 fi

--- a/files/internals/functions.apf
+++ b/files/internals/functions.apf
@@ -145,43 +145,43 @@ trim() {
 
 cli_trust_remove() {
 	DIP="$1"
-	$IPT -D INPUT -s $DIP -j ACCEPT
-	$IPT -D OUTPUT -d $DIP -j ACCEPT
-        $IPT -D INPUT -s $DIP -j $ALL_STOP
-        $IPT -D OUTPUT -d $DIP -j $ALL_STOP
+	$IPT $IPT_FLAGS -D INPUT -s $DIP -j ACCEPT
+	$IPT $IPT_FLAGS -D OUTPUT -d $DIP -j ACCEPT
+        $IPT $IPT_FLAGS -D INPUT -s $DIP -j $ALL_STOP
+        $IPT $IPT_FLAGS -D OUTPUT -d $DIP -j $ALL_STOP
 
-	$IPT -D TALLOW -s $DIP -j ACCEPT
-	$IPT -D TALLOW -d $DIP -j ACCEPT
-        $IPT -D TDENY -s $DIP -j $ALL_STOP
-        $IPT -D TDENY -d $DIP -j $ALL_STOP
+	$IPT $IPT_FLAGS -D TALLOW -s $DIP -j ACCEPT
+	$IPT $IPT_FLAGS -D TALLOW -d $DIP -j ACCEPT
+        $IPT $IPT_FLAGS -D TDENY -s $DIP -j $ALL_STOP
+        $IPT $IPT_FLAGS -D TDENY -d $DIP -j $ALL_STOP
 
-	$IPT -D TGALLOW -s $DIP -j ACCEPT
-	$IPT -D TGALLOW -d $DIP -j ACCEPT
-        $IPT -D TGDENY -s $DIP -j $ALL_STOP
-        $IPT -D TGDENY -d $DIP -j $ALL_STOP
+	$IPT $IPT_FLAGS -D TGALLOW -s $DIP -j ACCEPT
+	$IPT $IPT_FLAGS -D TGALLOW -d $DIP -j ACCEPT
+        $IPT $IPT_FLAGS -D TGDENY -s $DIP -j $ALL_STOP
+        $IPT $IPT_FLAGS -D TGDENY -d $DIP -j $ALL_STOP
 
 	sed -i "/$DIP/d" $ALLOW_HOSTS $DENY_HOSTS $GALLOW_HOSTS $GDENY_HOSTS
-	dil=`$IPT --numeric --list INPUT --line-numbers | grep -w $DIP | awk '{print$1}'`
-	dol=`$IPT --numeric --list OUTPUT --line-numbers | grep -w $DIP | awk '{print$1}'`
-	$IPT -D INPUT $dil >> /dev/null 2>&1
-	$IPT -D OUTPUT $dol >> /dev/null 2>&1
+	dil=`$IPT $IPT_FLAGS --numeric --list INPUT --line-numbers | grep -w $DIP | awk '{print$1}'`
+	dol=`$IPT $IPT_FLAGS --numeric --list OUTPUT --line-numbers | grep -w $DIP | awk '{print$1}'`
+	$IPT $IPT_FLAGS -D INPUT $dil >> /dev/null 2>&1
+	$IPT $IPT_FLAGS -D OUTPUT $dol >> /dev/null 2>&1
 
-	dil=`$IPT --numeric --list TALLOW --line-numbers | grep -w $DIP | tac | awk '{print$1}'`
-	dol=`$IPT --numeric --list TDENY --line-numbers | grep -w $DIP | tac | awk '{print$1}'`
+	dil=`$IPT $IPT_FLAGS --numeric --list TALLOW --line-numbers | grep -w $DIP | tac | awk '{print$1}'`
+	dol=`$IPT $IPT_FLAGS --numeric --list TDENY --line-numbers | grep -w $DIP | tac | awk '{print$1}'`
 	for i in `echo $dil`; do
-		$IPT -D TALLOW $i >> /dev/null 2>&1
+		$IPT $IPT_FLAGS -D TALLOW $i >> /dev/null 2>&1
 	done
 	for i in `echo $dol`; do
-		$IPT -D TDENY $i >> /dev/null 2>&1
+		$IPT $IPT_FLAGS -D TDENY $i >> /dev/null 2>&1
 	done
 
-	dil=`$IPT --numeric --list TGALLOW --line-numbers | grep -w $DIP | tac | awk '{print$1}'`
-	dol=`$IPT --numeric --list TGDENY --line-numbers | grep -w $DIP | tac | awk '{print$1}'`
+	dil=`$IPT $IPT_FLAGS --numeric --list TGALLOW --line-numbers | grep -w $DIP | tac | awk '{print$1}'`
+	dol=`$IPT $IPT_FLAGS --numeric --list TGDENY --line-numbers | grep -w $DIP | tac | awk '{print$1}'`
 	for i in `echo $dil`; do
-		$IPT -D TGALLOW $i >> /dev/null 2>&1
+		$IPT $IPT_FLAGS -D TGALLOW $i >> /dev/null 2>&1
 	done
 	for i in `echo $dol`; do
-		$IPT -D TGDENY $i >> /dev/null 2>&1
+		$IPT $IPT_FLAGS -D TGDENY $i >> /dev/null 2>&1
 	done
 }
 
@@ -214,8 +214,8 @@ cli_trust() {
 		elif [ "$ACTION" == "ALLOW" ]; then
 			JACTION="ACCEPT"
 		fi
-	        $IPT -I $CHAIN -s $HOST -j $JACTION
-	       	$IPT -I $CHAIN -d $HOST -j $JACTION
+	        $IPT $IPT_FLAGS -I $CHAIN -s $HOST -j $JACTION
+	       	$IPT $IPT_FLAGS -I $CHAIN -d $HOST -j $JACTION
 	        eout "(trust) added $ACTION all to/from $HOST"
 	        if [ ! "$SET_VERBOSE" == "1" ]; then
 		        echo "Inserted into firewall: $ACTION all to/from $HOST"
@@ -227,7 +227,7 @@ cli_trust() {
 }
 
 flush() {
-firewall_on=`iptables -L --numeric | grep -vE "Chain|destination"`
+firewall_on=`$IPT $IPT_FLAGS -L --numeric | grep -vE "Chain|destination"`
 if [ "$SET_FASTLOAD" == "1" ] && [ ! "$1" == "1" ] && [ ! "$DEVEL_ON" == "1" ] && [ ! "$firewall_on" == "" ]; then
 	$IPTS > $INSTALL_PATH/internals/.apf.restore
 	eout "{glob} fast load snapshot saved"
@@ -236,11 +236,11 @@ if [ ! "$1" = "1" ]; then
 	eout "{glob} flushing & zeroing chain policies"
 fi
 chains=`cat /proc/net/ip_tables_names 2>/dev/null`
-for i in $chains; do $IPT -t $i -F; done
-for i in $chains; do $IPT -t $i -X; done
-$IPT -P INPUT ACCEPT
-$IPT -P OUTPUT ACCEPT
-$IPT -P FORWARD ACCEPT
+for i in $chains; do $IPT $IPT_FLAGS -t $i -F; done
+for i in $chains; do $IPT $IPT_FLAGS -t $i -X; done
+$IPT $IPT_FLAGS -P INPUT ACCEPT
+$IPT $IPT_FLAGS -P OUTPUT ACCEPT
+$IPT $IPT_FLAGS -P FORWARD ACCEPT
 
 if [ "$USE_IPV6" == "1" ]; then
 	chains6=`cat /proc/net/ip6_tables_names 2>/dev/null`
@@ -265,7 +265,7 @@ list() {
 echo "Loading iptables rules..."
 iptc=/etc/apf/.iptrules.$$
 :> $iptc ; chmod 600 $iptc
-$IPT --verbose --numeric --line-numbers --list >> $iptc
+$IPT $IPT_FLAGS --verbose --numeric --line-numbers --list >> $iptc
 echo "Opening editor"
 if [ -f "/usr/bin/pico" ]; then
 	/usr/bin/pico -w $iptc
@@ -317,48 +317,48 @@ fi
 if [ ! "$TOS_0" == "" ]; then
         for i in `echo $TOS_0 | tr ',' ' '`; do
                 i=`echo $i | tr '_' ':'`
-                $IPT -t mangle -A $TYPE -p tcp --dport $i -j TOS --set-tos 0
-                $IPT -t mangle -A $TYPE -p udp --dport $i -j TOS --set-tos 0
+                $IPT $IPT_FLAGS -t mangle -A $TYPE -p tcp --dport $i -j TOS --set-tos 0
+                $IPT $IPT_FLAGS -t mangle -A $TYPE -p udp --dport $i -j TOS --set-tos 0
         done
 fi
 
 if [ ! "$TOS_2" == "" ]; then
         for i in `echo $TOS_2 | tr ',' ' '`; do
                 i=`echo $i | tr '_' ':'`
-                $IPT -t mangle -A $TYPE -p tcp --dport $i -j TOS --set-tos 2
-                $IPT -t mangle -A $TYPE -p udp --dport $i -j TOS --set-tos 2
+                $IPT $IPT_FLAGS -t mangle -A $TYPE -p tcp --dport $i -j TOS --set-tos 2
+                $IPT $IPT_FLAGS -t mangle -A $TYPE -p udp --dport $i -j TOS --set-tos 2
         done
 fi
 
 if [ ! "$TOS_4" == "" ]; then
         for i in `echo $TOS_4 | tr ',' ' '`; do
                 i=`echo $i | tr '_' ':'`
-                $IPT -t mangle -A $TYPE -p tcp --dport $i -j TOS --set-tos 4
-                $IPT -t mangle -A $TYPE -p udp --dport $i -j TOS --set-tos 4
+                $IPT $IPT_FLAGS -t mangle -A $TYPE -p tcp --dport $i -j TOS --set-tos 4
+                $IPT $IPT_FLAGS -t mangle -A $TYPE -p udp --dport $i -j TOS --set-tos 4
         done
 fi
 
 if [ ! "$TOS_8" == "" ]; then
         for i in `echo $TOS_8 | tr ',' ' '`; do
                 i=`echo $i | tr '_' ':'`
-                $IPT -t mangle -A $TYPE -p tcp --dport $i -j TOS --set-tos 8
-                $IPT -t mangle -A $TYPE -p udp --dport $i -j TOS --set-tos 8
+                $IPT $IPT_FLAGS -t mangle -A $TYPE -p tcp --dport $i -j TOS --set-tos 8
+                $IPT $IPT_FLAGS -t mangle -A $TYPE -p udp --dport $i -j TOS --set-tos 8
         done
 fi
 
 if [ ! "$TOS_16" == "" ]; then
         for i in `echo $TOS_16 | tr ',' ' '`; do
                 i=`echo $i | tr '_' ':'`
-                $IPT -t mangle -A $TYPE -p tcp --dport $i -j TOS --set-tos 16
-                $IPT -t mangle -A $TYPE -p udp --dport $i -j TOS --set-tos 16
+                $IPT $IPT_FLAGS -t mangle -A $TYPE -p tcp --dport $i -j TOS --set-tos 16
+                $IPT $IPT_FLAGS -t mangle -A $TYPE -p udp --dport $i -j TOS --set-tos 16
         done
 fi
 
 if [ ! "$TOS_DEF_RANGE" == "" ]; then
         for i in `echo $TOS_DEF_RANGE | tr ',' ' '`; do
                 i=`echo $i | tr '_' ':'`
-                $IPT -t mangle -A $TYPE -p tcp --dport $i -j TOS --set-tos $TOS_DEF
-                $IPT -t mangle -A $TYPE -p udp --dport $i -j TOS --set-tos $TOS_DEF
+                $IPT $IPT_FLAGS -t mangle -A $TYPE -p tcp --dport $i -j TOS --set-tos $TOS_DEF
+                $IPT $IPT_FLAGS -t mangle -A $TYPE -p udp --dport $i -j TOS --set-tos $TOS_DEF
         done
 fi
 }
@@ -386,8 +386,8 @@ if [ ! "`cat $file | grep -v "#"`" == "" ]; then
                 if [ ! "$val" ]; then
                  if [ ! "$i" == "" ] && [ -f "$file" ]; then
                         eout "{trust} allow all to/from $i"
-                        $IPT -A $chain -s $i -d 0/0 -j ACCEPT
-                        $IPT -A $chain -d $i -s 0/0 -j ACCEPT
+                        $IPT $IPT_FLAGS -A $chain -s $i -d 0/0 -j ACCEPT
+                        $IPT $IPT_FLAGS -A $chain -d $i -s 0/0 -j ACCEPT
                  fi
 		fi
         done
@@ -421,8 +421,8 @@ if [ ! "`cat $file | grep -v "#"`" == "" ]; then
 
                         if [ ! "$IPFLOW" == "" ] && [ ! "$PIP" == "" ] && [ ! "$IPFLOW" == "" ] && [ ! "$PPORT" == "" ]; then
                                 eout "{trust} allow $PIP $PFLOW_T port $PPORT"
-                                $IPT -A $chain -p tcp -m multiport -$IPFLOW $PIP --$PFLOW $PPORT -j ACCEPT
-                                $IPT -A $chain -p udp -m multiport -$IPFLOW $PIP --$PFLOW $PPORT -j ACCEPT
+                                $IPT $IPT_FLAGS -A $chain -p tcp -m multiport -$IPFLOW $PIP --$PFLOW $PPORT -j ACCEPT
+                                $IPT $IPT_FLAGS -A $chain -p udp -m multiport -$IPFLOW $PIP --$PFLOW $PPORT -j ACCEPT
                         fi
                 fi
         done
@@ -471,8 +471,8 @@ if [ ! "`cat $file | grep -v "#"`" == "" ]; then
                                 eout "{trust} ignored local ip allow rule '$NFLOW_T $PIP $PFLOW_T port $PPORT'"
                          else
                                 eout "{trust} allow $NFLOW_T $PIP $PFLOW_T port $PPORT"
-                                $IPT -A $chain -p tcp -m multiport -$IPFLOW $PIP --$PFLOW $PPORT -j ACCEPT
-                                $IPT -A $chain -p udp -m multiport -$IPFLOW $PIP --$PFLOW $PPORT -j ACCEPT
+                                $IPT $IPT_FLAGS -A $chain -p tcp -m multiport -$IPFLOW $PIP --$PFLOW $PPORT -j ACCEPT
+                                $IPT $IPT_FLAGS -A $chain -p udp -m multiport -$IPFLOW $PIP --$PFLOW $PPORT -j ACCEPT
                          fi
                         fi
                 fi
@@ -530,10 +530,10 @@ if [ ! "`cat $file | grep -v "#"`" == "" ]; then
                          else
                                 if [ "$PTYPE" == "tcp" ]; then
 	                                eout "{trust} allow $NFLOW_T $PTYPE $PIP $PFLOW_T port $PPORT"
-	                                $IPT -A $chain -p $PTYPE -m multiport -$IPFLOW $PIP --$PFLOW $PPORT -j ACCEPT
+	                                $IPT $IPT_FLAGS -A $chain -p $PTYPE -m multiport -$IPFLOW $PIP --$PFLOW $PPORT -j ACCEPT
                                 elif [ "$PTYPE" == "udp" ]; then
                                         eout "{trust} allow $NFLOW_T $PTYPE $PIP $PFLOW_T port $PPORT"
-		                        $IPT -A $chain -p $PTYPE -m multiport -$IPFLOW $PIP --$PFLOW $PPORT -j ACCEPT
+		                        $IPT $IPT_FLAGS -A $chain -p $PTYPE -m multiport -$IPFLOW $PIP --$PFLOW $PPORT -j ACCEPT
                                 fi
                          fi
                         fi
@@ -562,8 +562,8 @@ if [ ! "`cat $file | grep -v "#"`" == "" ]; then
                 if [ ! "$val" ]; then
                  if [ ! "$i" == "" ] && [ -f "$file" ]; then
                         eout "{trust} deny all to/from $i"
-                        $IPT -A $chain -s $i -d 0/0 -j $ALL_STOP
-                        $IPT -A $chain -d $i -s 0/0 -j $ALL_STOP
+                        $IPT $IPT_FLAGS -A $chain -s $i -d 0/0 -j $ALL_STOP
+                        $IPT $IPT_FLAGS -A $chain -d $i -s 0/0 -j $ALL_STOP
                  fi
 		fi
         done
@@ -597,8 +597,8 @@ if [ ! "`cat $file | grep -v "#"`" == "" ]; then
 
                         if [ ! "$IPFLOW" == "" ] && [ ! "$PIP" == "" ] && [ ! "$IPFLOW" == "" ] && [ ! "$PPORT" == "" ]; then
                                 eout "{trust} deny $PIP $PFLOW_T port $PPORT"
-                                $IPT -A $chain -p tcp -m multiport -$IPFLOW $PIP --$PFLOW $PPORT -j $TCP_STOP
-				$IPT -A $chain -p udp -m multiport -$IPFLOW $PIP --$PFLOW $PPORT -j $UDP_STOP
+                                $IPT $IPT_FLAGS -A $chain -p tcp -m multiport -$IPFLOW $PIP --$PFLOW $PPORT -j $TCP_STOP
+				$IPT $IPT_FLAGS -A $chain -p udp -m multiport -$IPFLOW $PIP --$PFLOW $PPORT -j $UDP_STOP
                         fi
                 fi
         done
@@ -642,8 +642,8 @@ if [ ! "`cat $file | grep -v "#"`" == "" ]; then
 
                         if [ ! "$NFLOW" == "" ] && [ ! "$IPFLOW" == "" ] && [ ! "$PIP" == "" ] && [ ! "$IPFLOW" == "" ] && [ ! "$PPORT" == "" ]; then
                                 eout "{trust} deny ($NFLOW_T) $PIP $PFLOW_T port $PPORT"
-                                $IPT -A $chain -p tcp -m multiport -$IPFLOW $PIP --$PFLOW $PPORT -j $TCP_STOP
-				$IPT -A $chain -p udp -m multiport -$IPFLOW $PIP --$PFLOW $PPORT -j $UDP_STOP
+                                $IPT $IPT_FLAGS -A $chain -p tcp -m multiport -$IPFLOW $PIP --$PFLOW $PPORT -j $TCP_STOP
+				$IPT $IPT_FLAGS -A $chain -p udp -m multiport -$IPFLOW $PIP --$PFLOW $PPORT -j $UDP_STOP
                         fi
                 fi
         done
@@ -695,10 +695,10 @@ if [ ! "`cat $file | grep -v "#"`" == "" ]; then
                         if [ ! "$PTYPE" == "" ] && [ ! "$NFLOW" == "" ] && [ ! "$IPFLOW" == "" ] && [ ! "$PIP" == "" ] && [ ! "$IPFLOW" == "" ] && [ ! "$PPORT" == "" ]; then
 				if [ "$PTYPE" == "tcp" ]; then
         	                        eout "{trust} deny $NFLOW_T $PTYPE $PIP $PFLOW_T port $PPORT"
-	                                $IPT -A $chain -p $PTYPE -m multiport -$IPFLOW $PIP --$PFLOW $PPORT -j $TCP_STOP
+	                                $IPT $IPT_FLAGS -A $chain -p $PTYPE -m multiport -$IPFLOW $PIP --$PFLOW $PPORT -j $TCP_STOP
 				elif [ "$PTYPE" == "udp" ]; then
 	                                eout "{trust} deny $NFLOW_T $PTYPE $PIP $PFLOW_T port $PPORT"
-					$IPT -A $chain -p $PTYPE -m multiport -$IPFLOW $PIP --$PFLOW $PPORT -j $UDP_STOP
+					$IPT $IPT_FLAGS -A $chain -p $PTYPE -m multiport -$IPFLOW $PIP --$PFLOW $PPORT -j $UDP_STOP
 				fi
                         fi
                 fi
@@ -774,17 +774,17 @@ fi
 dlist_php_hosts() {
 if [ ! "`cat $PHP_HOSTS | grep -v "#"`" == "" ]; then
         eout "{php} loading php_hosts.rules"
-        $IPT -N PHP
+        $IPT $IPT_FLAGS -N PHP
         for i in `cat $PHP_HOSTS | grep -v "#"`; do
                 if [ ! "$i" == "" ] && [ -f "$PHP_HOSTS" ]; then
 		        if [ "$LOG_DROP" == "1" ]; then
-                         $IPT -A PHP -s $i -d 0/0 -m limit --limit=$LOG_RATE/minute -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix="** PHP ** "
+                         $IPT $IPT_FLAGS -A PHP -s $i -d 0/0 -m limit --limit=$LOG_RATE/minute -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix="** PHP ** "
 			fi
-                        $IPT -A PHP -s $i -d 0/0 -j $ALL_STOP
+                        $IPT $IPT_FLAGS -A PHP -s $i -d 0/0 -j $ALL_STOP
                 fi
         done
-        $IPT -A INPUT -j PHP
-        $IPT -A OUTPUT -j PHP
+        $IPT $IPT_FLAGS -A INPUT -j PHP
+        $IPT $IPT_FLAGS -A OUTPUT -j PHP
 fi
 }
 
@@ -822,17 +822,17 @@ fi
 dlist_dshield_hosts() {
 if [ ! "`cat $DS_HOSTS | grep -v "#"`" == "" ]; then
         eout "{dshield} loading ds_hosts.rules"
-        $IPT -N DSHIELD
+        $IPT $IPT_FLAGS -N DSHIELD
         for i in `cat $DS_HOSTS | grep -v "#"`; do
                 if [ ! "$i" == "" ] && [ -f "$DS_HOSTS" ]; then
 		        if [ "$LOG_DROP" == "1" ]; then
-                         $IPT -A DSHIELD -s $i -d 0/0 -m limit --limit=$LOG_RATE/minute -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix="** DSHIELD ** "
+                         $IPT $IPT_FLAGS -A DSHIELD -s $i -d 0/0 -m limit --limit=$LOG_RATE/minute -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix="** DSHIELD ** "
 			fi
-                        $IPT -A DSHIELD -s $i -d 0/0 -j $ALL_STOP
+                        $IPT $IPT_FLAGS -A DSHIELD -s $i -d 0/0 -j $ALL_STOP
                 fi
         done
-        $IPT -A INPUT -j DSHIELD
-        $IPT -A OUTPUT -j DSHIELD
+        $IPT $IPT_FLAGS -A INPUT -j DSHIELD
+        $IPT $IPT_FLAGS -A OUTPUT -j DSHIELD
 fi
 }
 
@@ -871,17 +871,17 @@ fi
 dlist_spamhaus_hosts() {
 if [ ! "`cat $DROP_HOSTS | grep -v "#"`" == "" ]; then
         eout "{sdrop} loading sdrop_hosts.rules"
-        $IPT -N SDROP
+        $IPT $IPT_FLAGS -N SDROP
         for i in `cat $DROP_HOSTS | grep -v "#"`; do
                 if [ ! "$i" == "" ] && [ -f "$DROP_HOSTS" ]; then
 		        if [ "$LOG_DROP" == "1" ]; then
-                         $IPT -A SDROP -s $i -d 0/0 -m limit --limit=$LOG_RATE/minute -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix="** SDROP ** "
+                         $IPT $IPT_FLAGS -A SDROP -s $i -d 0/0 -m limit --limit=$LOG_RATE/minute -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix="** SDROP ** "
 		        fi
-                        $IPT -A SDROP -s $i -d 0/0 -j $ALL_STOP
+                        $IPT $IPT_FLAGS -A SDROP -s $i -d 0/0 -j $ALL_STOP
                 fi
         done
-        $IPT -A INPUT -j SDROP
-        $IPT -A OUTPUT -j SDROP
+        $IPT $IPT_FLAGS -A INPUT -j SDROP
+        $IPT $IPT_FLAGS -A OUTPUT -j SDROP
 fi
 }
 
@@ -921,7 +921,7 @@ if [ ! "`cat $ECNSHAME_HOSTS | grep -v "#"`" == "" ]; then
         eout "{ecnshame} loading ecnshame_hosts.rules"
         for i in `cat $ECNSHAME_HOSTS | grep -v "#"`; do
                 if [ ! "$i" == "" ] && [ -f "$ECNSHAME_HOSTS" ]; then
-			$IPT -t mangle -A POSTROUTING -p tcp -d $i -j ECN --ecn-tcp-remove
+			$IPT $IPT_FLAGS -t mangle -A POSTROUTING -p tcp -d $i -j ECN --ecn-tcp-remove
                 fi
         done
 fi
@@ -982,8 +982,8 @@ FNAME=`echo $FILE | tr '/' '\n' | tail -n 1`
 eout "{glob} loading $FNAME"
  for i in `cat $FILE | grep -v "#"`; do
   if [ ! "$i" == "" ]; then
-        $IPT -A INPUT -s $i -j $ALL_STOP
-	$IPT -A OUTPUT -d $i -j $ALL_STOP
+        $IPT $IPT_FLAGS -A INPUT -s $i -j $ALL_STOP
+	$IPT $IPT_FLAGS -A OUTPUT -d $i -j $ALL_STOP
   fi
  done
 fi
@@ -1002,20 +1002,20 @@ if [ ! "$BLK_PORTS" == "" ]; then
 for i in `echo $BLK_PORTS | tr ',' ' '`; do
 	if [ "$(echo $i | grep "_")" == "" ]; then
          if [ ! "$i" == "" ]; then
-		$IPT -A INPUT  -p tcp --dport $i -j $TCP_STOP
-		$IPT -A INPUT  -p udp --dport $i -j $UDP_STOP
-		$IPT -A OUTPUT  -p tcp --dport $i -j $TCP_STOP
-		$IPT -A OUTPUT  -p udp --dport $i -j $UDP_STOP
+		$IPT $IPT_FLAGS -A INPUT  -p tcp --dport $i -j $TCP_STOP
+		$IPT $IPT_FLAGS -A INPUT  -p udp --dport $i -j $UDP_STOP
+		$IPT $IPT_FLAGS -A OUTPUT  -p tcp --dport $i -j $TCP_STOP
+		$IPT $IPT_FLAGS -A OUTPUT  -p udp --dport $i -j $UDP_STOP
 		eout "{blk_ports} deny all to/from tcp port $i"
                 eout "{blk_ports} deny all to/from udp port $i"
          fi
         else
                 i=`echo $i | tr '_' ':'`
                 if [ ! "$i" == "" ]; then
-			$IPT -A INPUT  -p tcp --dport $i -j $TCP_STOP
-			$IPT -A INPUT  -p udp --dport $i -j $UDP_STOP
-			$IPT -A OUTPUT  -p tcp --dport $i -j $TCP_STOP
-			$IPT -A OUTPUT  -p udp --dport $i -j $UDP_STOP
+			$IPT $IPT_FLAGS -A INPUT  -p tcp --dport $i -j $TCP_STOP
+			$IPT $IPT_FLAGS -A INPUT  -p udp --dport $i -j $UDP_STOP
+			$IPT $IPT_FLAGS -A OUTPUT  -p tcp --dport $i -j $TCP_STOP
+			$IPT $IPT_FLAGS -A OUTPUT  -p udp --dport $i -j $UDP_STOP
         	        eout "{blk_ports} deny all to/from tcp port $i"
 	                eout "{blk_ports} deny all to/from udp port $i"
                 fi
@@ -1025,19 +1025,19 @@ fi
 }
 
 lgate_mac() {
-$IPT -N LMAC
+$IPT $IPT_FLAGS -N LMAC
 for mac in `echo $LGATE_MAC | tr ',' ' '`; do
 MAC=$mac
 if [ ! "$MAC" == "" ]; then
-  $IPT -A INPUT  -m mac ! --mac-source "$MAC" -j LMAC
+  $IPT $IPT_FLAGS -A INPUT  -m mac ! --mac-source "$MAC" -j LMAC
   eout "{glob} gateway ($MAC) route verification enabled"
 fi
 done
 
 if [ "$LOG_LGATE" == "1" ]; then
- $IPT -A LMAC -m limit --limit $LOG_RATE/minute -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix=" ** DROP FORIGN MAC ** "
+ $IPT $IPT_FLAGS -A LMAC -m limit --limit $LOG_RATE/minute -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix=" ** DROP FORIGN MAC ** "
 fi
-$IPT -A LMAC  -j REJECT --reject-with icmp-net-prohibited
+$IPT $IPT_FLAGS -A LMAC  -j REJECT --reject-with icmp-net-prohibited
 }
 
 cl_cports() {
@@ -1083,7 +1083,7 @@ fi
 }
 
 refresh() {
-	apf_loaded=`$IPT --list --numeric | grep PROHIBIT`
+	apf_loaded=`$IPT $IPT_FLAGS --list --numeric | grep PROHIBIT`
 	if [ -z "$apf_loaded" ]; then
 	        eout "{glob} apf does not appear to have rules loaded, doing nothing."
 	        mutex_unlock
@@ -1121,33 +1121,33 @@ refresh() {
 	fi
 
         /sbin/iptables-save | grep -E "TALLOW|TGALLOW" | grep -E '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+' | awk '{print$4}' | sort -n | uniq > $tmpra
-        $IPT -F REFRESH_TEMP
+        $IPT $IPT_FLAGS -F REFRESH_TEMP
         for i in `cat $tmpra | grep -v "#"`; do
                 if [ ! "$i" == "" ]; then
-                 $IPT -A REFRESH_TEMP -s $i -d 0/0 -j ACCEPT
-                 $IPT -A REFRESH_TEMP -d $i -s 0/0 -j ACCEPT
+                 $IPT $IPT_FLAGS -A REFRESH_TEMP -s $i -d 0/0 -j ACCEPT
+                 $IPT $IPT_FLAGS -A REFRESH_TEMP -d $i -s 0/0 -j ACCEPT
                 fi
         done
         tmprd="/etc/apf/internals/refresh.drop.temp.$$"
         /sbin/iptables-save | grep -E "TDENY|TGDENY" | grep -E '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+' | awk '{print$4}' | sort -n | uniq > $tmprd
-        $IPT -F REFRESH_TEMP
+        $IPT $IPT_FLAGS -F REFRESH_TEMP
         for i in `cat $tmprd | grep -v "#"`; do
                 if [ ! "$i" == "" ]; then
-                 $IPT -A REFRESH_TEMP -s $i -d 0/0 -j $ALL_STOP
-                 $IPT -A REFRESH_TEMP -d $i -s 0/0 -j $ALL_STOP
+                 $IPT $IPT_FLAGS -A REFRESH_TEMP -s $i -d 0/0 -j $ALL_STOP
+                 $IPT $IPT_FLAGS -A REFRESH_TEMP -d $i -s 0/0 -j $ALL_STOP
                 fi
         done
         trim $DENY_HOSTS $SET_TRIM
         trim $GDENY_HOSTS $SET_TRIM
-        $IPT -F TDENY
-        $IPT -F TGDENY
-        $IPT -F TALLOW
-        $IPT -F TGALLOW
+        $IPT $IPT_FLAGS -F TDENY
+        $IPT $IPT_FLAGS -F TGDENY
+        $IPT $IPT_FLAGS -F TALLOW
+        $IPT $IPT_FLAGS -F TGALLOW
 	allow_hosts $GALLOW_HOSTS TGALLOW
 	allow_hosts $ALLOW_HOSTS TALLOW
 	deny_hosts $GDENY_HOSTS TGDENY
 	deny_hosts $DENY_HOSTS TDENY
-        $IPT -F REFRESH_TEMP
+        $IPT $IPT_FLAGS -F REFRESH_TEMP
         rm -f $tmpra $tmprd
 }
 

--- a/files/internals/internals.conf
+++ b/files/internals/internals.conf
@@ -50,11 +50,7 @@ LOCK_TIMEOUT="300"
 ENTER_LOCK_TIMEOUT="60"
 LOCK_FILE="$INSTALL_PATH/lock.utime"
 
-# iptables lock time (only available >= 1.4.20)
-IPT_LOCK_TIMEOUT="3"
-
-IPT_VERSION=`$IPT --version | grep -Po '(\d)+\.(\d)+\.(\d)+$'`
-if [[ -n "$IPT_VERSION" && "1.4.20" == "`echo -e "1.4.20\n$IPT_VERSION" | sort -V | head -n1`" ]]; then
+if [[ "$IPT_LOCK_SUPPORT" == "1" ]]; then
   IPT_FLAGS="$IPT_FLAGS -w $IPT_LOCK_TIMEOUT"
 fi
 

--- a/files/internals/internals.conf
+++ b/files/internals/internals.conf
@@ -50,6 +50,14 @@ LOCK_TIMEOUT="300"
 ENTER_LOCK_TIMEOUT="60"
 LOCK_FILE="$INSTALL_PATH/lock.utime"
 
+# iptables lock time (only available >= 1.4.20)
+IPT_LOCK_TIMEOUT="3"
+
+IPT_VERSION=`$IPT --version | grep -Po '(\d)+\.(\d)+\.(\d)+$'`
+if [[ -n "$IPT_VERSION" && "1.4.20" == "`echo -e "1.4.20\n$IPT_VERSION" | sort -V | head -n1`" ]]; then
+  IPT_FLAGS="$IPT_FLAGS -w $IPT_LOCK_TIMEOUT"
+fi
+
 ADR="$INSTALL_PATH/ad/ad.rules"
 ALLOW_HOSTS="$INSTALL_PATH/allow_hosts.rules"
 DENY_HOSTS="$INSTALL_PATH/deny_hosts.rules"

--- a/files/log.rules
+++ b/files/log.rules
@@ -2,11 +2,11 @@ eout "{glob} loading log.rules"
 
 if [ "$LOG_DROP" == "1" ]; then
  if [ "$LOG_IA" == "1" ]; then
-	$IPT -N TELNET_LOG
-	$IPT -A TELNET_LOG -p tcp -s 0/0 -d 0/0 --dport 23 -m state --state NEW -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix "** TELNET ** "
-	$IPT -N SSH_LOG
-	$IPT -A SSH_LOG -p tcp -s 0/0 -d 0/0 --dport $HELPER_SSH_PORT -m state --state NEW -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix "** SSH ** "
-	$IPT -A INPUT -j TELNET_LOG
-	$IPT -A INPUT -j SSH_LOG
+	$IPT $IPT_FLAGS -N TELNET_LOG
+	$IPT $IPT_FLAGS -A TELNET_LOG -p tcp -s 0/0 -d 0/0 --dport 23 -m state --state NEW -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix "** TELNET ** "
+	$IPT $IPT_FLAGS -N SSH_LOG
+	$IPT $IPT_FLAGS -A SSH_LOG -p tcp -s 0/0 -d 0/0 --dport $HELPER_SSH_PORT -m state --state NEW -j $LOG_TARGET --log-level=$LOG_LEVEL $LEXT --log-prefix "** SSH ** "
+	$IPT $IPT_FLAGS -A INPUT -j TELNET_LOG
+	$IPT $IPT_FLAGS -A INPUT -j SSH_LOG
  fi
 fi


### PR DESCRIPTION
When two instances of the `iptables` command are ran simultaneously they often encounter a race condition resulting in one of the commands not being executed. mutex_lock/unlock stops two instances of `apf` from colliding, but external programs that call `iptables` directly may result in `apf` not adding the necessary rules.

In 1.4.20, iptables added native support for locking, as well as a wait timeout flag:

http://git.netfilter.org/iptables/commit/?id=93587a04d0f2511e108bbc4d87a8b9d28a5c5dd8
http://git.netfilter.org/iptables/commit/?id=d7aeda5ed45ac7ca959f12180690caa371b5b14b

This PR adds the flag with a default timeout of 3 seconds when iptables is >= 1.4.20.