### PR TITLE
Attempt to load rules even if monokern

### DIFF
--- a/files/internals/functions.apf
+++ b/files/internals/functions.apf
@@ -63,12 +63,12 @@ modinit() {
  if [ ! "$SET_MONOKERN" == "1" ]; then
         # Loading Kernel Modules
         ml ip_tables 1
+ fi
 	modlist="ip_conntrack ip_conntrack_ftp ip_conntrack_irc iptable_filter iptable_mangle ipt_ecn ipt_length ipt_limit ipt_LOG ipt_mac ipt_multiport ipt_owner ipt_recent ipt_REJECT ipt_state ipt_TCPMSS ipt_TOS ipt_ttl ipt_ULOG nf_conntrack nf_conntrack_ftp nf_conntrack_irc xt_conntrack xt_conntrack_ftp xt_conntrack_irc xt_ecn xt_length xt_limit xt_LOG xt_mac xt_multiport xt_owner xt_recent xt_REJECT xt_state xt_TCPMSS xt_TOS xt_ttl xt_ULOG"
 	for mod in $modlist; do
 		ml $mod
 	done
 
- fi
 }
 
 check_rab() {


### PR DESCRIPTION
With SET_MONOKERN enabled we skip loading a bunch of kernel modules that do not seem to be present in some MONOKERN kernels. For example the 4.19.113-300.el7.x86_64 altarch kernel for CentOS 7 does not have a ip_tables module but has a bunch of the modules in modlist as individual modules. Thus setting SET_MONOKERN to 1 we skip a bunch of these useful modules.