### PR TITLE
fixed vnetgen to newer linux distros

### DIFF
--- a/README
+++ b/README
@@ -199,7 +199,7 @@ Fedora Core Any
 Slackware 8.0+
 Debian GNU/Linux 3.0+
 Suse Linux 8.1+
-Unbuntu Any
+Ubuntu Any
 TurboLinux Server 9+
 TurboLinux Fuji (Desktop)
 RedHat Linux 7.3,8,9

--- a/files/vnet/vnetgen
+++ b/files/vnet/vnetgen
@@ -20,22 +20,22 @@ if [ "$SET_VNET" == "0" ]; then
 fi
 
 if [ ! -f "$INSTALL_PATH/vnet/vnetgen.def" ]; then
-        echo "vnetgen.def not found, aborting."
-        exit 1
+  echo "vnetgen.def not found, aborting."
+  exit 1
 fi
 
 if [ ! -f "$ip" ] && [ ! -f "$ifconfig" ]; then
-        eout "{glob} $ip and $ifconfig not found; aborting"
-	echo "$ip and $ifconfig not found; aborting"
-        exit 1
+  eout "{glob} $ip and $ifconfig not found; aborting"
+  echo "$ip and $ifconfig not found; aborting"
+  exit 1
 elif [ -f "$ip" ]; then
- for addr in `/sbin/ip addr list | tr '/' ' ' | grep -w inet | grep -w $IF | grep -v 127.0.0.1 | grep -vw $NET | awk '{print$2}'`; do
-  if [ ! -f "$INSTALL_PATH/vnet/$addr.rules" ]; then
-        touch $INSTALL_PATH/vnet/$addr.rules
-        chmod 600 $INSTALL_PATH/vnet/$addr.rules
-        . $INSTALL_PATH/vnet/vnetgen.def
-  fi
- done
+  for addr in `/sbin/ip addr list | tr '/' ' ' | grep -w inet | grep -w $IF | grep -v 127.0.0.1 | grep -vw $NET | awk '{print$2}'`; do
+    if [ ! -f "$INSTALL_PATH/vnet/$addr.rules" ]; then
+      touch $INSTALL_PATH/vnet/$addr.rules
+      chmod 600 $INSTALL_PATH/vnet/$addr.rules
+      . $INSTALL_PATH/vnet/vnetgen.def
+    fi
+  done
 elif [ -f "$ifconfig" ]; then
 for iface in `ifconfig | grep -w $IF | awk '{print$1}'`; do
   for addr in `ifconfig $iface | grep -w inet | tr ':' ' ' | grep -vw $NET | awk '{print$3}'`; do
@@ -48,34 +48,41 @@ for iface in `ifconfig | grep -w $IF | awk '{print$1}'`; do
 done
 fi
 
+# use ip as default as newer linux tend to not use ifconfig anymore
+if [ -f "$ip" ]; then
+  SEARCH_IFACES=$(ip link | grep -w mtu | tr ": " " " | awk '{print $2}' | grep -vwE "lo|$IFACE_UNTRUSTED")
+elif [ -f "$ifconfig" ]; then
+  # ifconfig changed from old versions (Ubuntu 12 maybe 14), which contains "Link" on interface lines. 
+  # On newer ifconfig (Ubuntu 16+) ifconfig line contains "mtu" on interface lines
+  ifconfig | grep -q Link
+  if [[ $? -eq 0 ]]; then
+      SEARCH_IFACES=$(ifconfig | grep Link | grep -vwE "inet|inet6|lo|$IFACE_UNTRUSTED" | awk '{print$1}')
+  else
+      SEARCH_IFACES=$(ifconfig | grep mtu | grep -vwE "inet|inet6|lo|$IFACE_UNTRUSTED" | tr ":" " " | awk '{print$1}')
+  fi
+fi
 
 if [ "$SET_ADDIFACE" == "1" ]; then
- ## associate a vnet rule for ip's on additional interfaces other than the main
- for anet in `ifconfig | grep Link | grep -vwE "inet|inet6|lo|$IFACE_UNTRUSTED|$IFACE_UNTRUSTED" | awk '{print$1}'`; do
-  if [ -f "$ip" ]; then
-  valtif=`echo $TIF | grep $anet`
-   if [ "$valtif" == "" ]; then
-    for addr in `/sbin/ip addr list | tr '/' ' ' | grep -w inet | grep -w $anet | grep -v 127.0.0.1 | grep -vw $NET | awk '{print$2}'`; do
-     if [ ! -f "$INSTALL_PATH/vnet/$addr.rules" ]; then
-        touch $INSTALL_PATH/vnet/$addr.rules
-        chmod 600 $INSTALL_PATH/vnet/$addr.rules
-        . $INSTALL_PATH/vnet/vnetgen.def
-     fi
-    done
-   fi
-  elif [ -f "$ifconfig" ]; then
-   for iface in `ifconfig | grep -w $anet | awk '{print$1}'`; do
-    valtif=`echo $TIF | grep $anet`
-    if [ "$valtif" == "" ]; then 
-     for addr in `ifconfig $iface | grep -w inet | tr ':' ' ' | grep -vw $NET | awk '{print$3}'`; do
-      if [ ! -f "$INSTALL_PATH/vnet/$addr.rules" ]; then
-        touch $INSTALL_PATH/vnet/$addr.rules
-        chmod 600 $INSTALL_PATH/vnet/$addr.rules
-        . $INSTALL_PATH/vnet/vnetgen.def
-      fi
-     done
+  ## associate a vnet rule for ip's on additional interfaces other than the main
+  for anet in $SEARCH_IFACES; do
+    if [ -f "$ip" ]; then
+      for addr in `/sbin/ip addr list | tr '/' ' ' | grep -w inet | grep -w $anet | grep -v 127.0.0.1 | grep -vw $NET | awk '{print$2}'`; do
+        if [ ! -f "$INSTALL_PATH/vnet/$addr.rules" ]; then
+          touch $INSTALL_PATH/vnet/$addr.rules
+          chmod 600 $INSTALL_PATH/vnet/$addr.rules
+          . $INSTALL_PATH/vnet/vnetgen.def
+        fi
+      done
+    elif [ -f "$ifconfig" ]; then
+      for iface in `ifconfig | grep -w $anet | awk '{print$1}'`; do
+        for addr in `ifconfig $iface | grep -w inet | tr ':' ' ' | grep -vw $NET | awk '{print$3}'`; do
+          if [ ! -f "$INSTALL_PATH/vnet/$addr.rules" ]; then
+            touch $INSTALL_PATH/vnet/$addr.rules
+            chmod 600 $INSTALL_PATH/vnet/$addr.rules
+            . $INSTALL_PATH/vnet/vnetgen.def
+          fi
+        done
+      done
     fi
-   done
-  fi
- done
+  done
 fi

--- a/test/distros_examples/ifconfig_ubuntu_12
+++ b/test/distros_examples/ifconfig_ubuntu_12
@@ -1,0 +1,84 @@
+eth0      Link encap:Ethernet  HWaddr 00:15:5d:83:e8:d1  
+          inet addr:192.168.4.89  Bcast:192.168.4.255  Mask:255.255.255.0
+          inet6 addr: fe80::215:5dff:fe83:e8d1/64 Scope:Link
+          UP BROADCAST RUNNING MULTICAST  MTU:1500  Metric:1
+          RX packets:547895 errors:0 dropped:0 overruns:0 frame:0
+          TX packets:345368 errors:0 dropped:0 overruns:0 carrier:0
+          collisions:0 txqueuelen:1000 
+          RX bytes:67307038 (67.3 MB)  TX bytes:29762680 (29.7 MB)
+
+eth1      Link encap:Ethernet  HWaddr 00:15:5d:83:e8:d2  
+          inet addr:10.100.2.196  Bcast:10.100.2.255  Mask:255.255.255.0
+          inet6 addr: fe80::215:5dff:fe83:e8d2/64 Scope:Link
+          UP BROADCAST RUNNING MULTICAST  MTU:1500  Metric:1
+          RX packets:172399 errors:0 dropped:0 overruns:0 frame:0
+          TX packets:146988 errors:0 dropped:0 overruns:0 carrier:0
+          collisions:0 txqueuelen:1000 
+          RX bytes:197526405 (197.5 MB)  TX bytes:80391764 (80.3 MB)
+
+eth2      Link encap:Ethernet  HWaddr 00:15:5d:83:e8:d3  
+          inet addr:10.100.6.10  Bcast:10.100.6.255  Mask:255.255.255.0
+          inet6 addr: fe80::215:5dff:fe83:e8d3/64 Scope:Link
+          UP BROADCAST RUNNING MULTICAST  MTU:1500  Metric:1
+          RX packets:760 errors:0 dropped:0 overruns:0 frame:0
+          TX packets:679 errors:0 dropped:0 overruns:0 carrier:0
+          collisions:0 txqueuelen:1000 
+          RX bytes:57319 (57.3 KB)  TX bytes:30650 (30.6 KB)
+
+eth3      Link encap:Ethernet  HWaddr 00:15:5d:83:e8:d4  
+          inet addr:10.100.7.6  Bcast:10.100.7.255  Mask:255.255.255.0
+          inet6 addr: fe80::215:5dff:fe83:e8d4/64 Scope:Link
+          UP BROADCAST RUNNING MULTICAST  MTU:1500  Metric:1
+          RX packets:4 errors:0 dropped:0 overruns:0 frame:0
+          TX packets:4 errors:0 dropped:0 overruns:0 carrier:0
+          collisions:0 txqueuelen:1000 
+          RX bytes:368 (368.0 B)  TX bytes:368 (368.0 B)
+
+eth4      Link encap:Ethernet  HWaddr 00:15:5d:83:e8:d5  
+          inet addr:10.150.0.35  Bcast:10.150.0.255  Mask:255.255.255.0
+          inet6 addr: fe80::215:5dff:fe83:e8d5/64 Scope:Link
+          UP BROADCAST RUNNING MULTICAST  MTU:1500  Metric:1
+          RX packets:2805 errors:0 dropped:0 overruns:0 frame:0
+          TX packets:2643 errors:0 dropped:0 overruns:0 carrier:0
+          collisions:0 txqueuelen:1000 
+          RX bytes:197518 (197.5 KB)  TX bytes:143060 (143.0 KB)
+
+eth5      Link encap:Ethernet  HWaddr 00:15:5d:83:e8:d6  
+          inet addr:192.168.6.221  Bcast:192.168.6.255  Mask:255.255.255.0
+          inet6 addr: fe80::215:5dff:fe83:e8d6/64 Scope:Link
+          UP BROADCAST RUNNING MULTICAST  MTU:1500  Metric:1
+          RX packets:11586 errors:0 dropped:0 overruns:0 frame:0
+          TX packets:4 errors:0 dropped:0 overruns:0 carrier:0
+          collisions:0 txqueuelen:1000 
+          RX bytes:1103720 (1.1 MB)  TX bytes:368 (368.0 B)
+
+eth6      Link encap:Ethernet  HWaddr 00:15:5d:83:e8:d7  
+          inet addr:10.66.0.9  Bcast:10.66.15.255  Mask:255.255.240.0
+          inet6 addr: fe80::215:5dff:fe83:e8d7/64 Scope:Link
+          UP BROADCAST RUNNING MULTICAST  MTU:1500  Metric:1
+          RX packets:215095 errors:0 dropped:0 overruns:0 frame:0
+          TX packets:4 errors:0 dropped:0 overruns:0 carrier:0
+          collisions:0 txqueuelen:1000 
+          RX bytes:39040210 (39.0 MB)  TX bytes:368 (368.0 B)
+
+eth7      Link encap:Ethernet  HWaddr 00:15:5d:83:e8:d8  
+          inet addr:10.16.17.55  Bcast:10.16.17.255  Mask:255.255.255.0
+          inet6 addr: fe80::215:5dff:fe83:e8d8/64 Scope:Link
+          UP BROADCAST RUNNING MULTICAST  MTU:1500  Metric:1
+          RX packets:586341 errors:0 dropped:0 overruns:0 frame:0
+          TX packets:534037 errors:0 dropped:0 overruns:0 carrier:0
+          collisions:0 txqueuelen:1000 
+          RX bytes:136742137 (136.7 MB)  TX bytes:88015598 (88.0 MB)
+
+eth7:0    Link encap:Ethernet  HWaddr 00:15:5d:83:e8:d8  
+          inet addr:128.1.1.1  Bcast:128.1.1.255  Mask:255.255.255.0
+          UP BROADCAST RUNNING MULTICAST  MTU:1500  Metric:1
+
+lo        Link encap:Local Loopback  
+          inet addr:127.0.0.1  Mask:255.0.0.0
+          inet6 addr: ::1/128 Scope:Host
+          UP LOOPBACK RUNNING  MTU:65536  Metric:1
+          RX packets:32904 errors:0 dropped:0 overruns:0 frame:0
+          TX packets:32904 errors:0 dropped:0 overruns:0 carrier:0
+          collisions:0 txqueuelen:0 
+          RX bytes:3629713 (3.6 MB)  TX bytes:3629713 (3.6 MB)

--- a/test/distros_examples/ifconfig_ubuntu_20
+++ b/test/distros_examples/ifconfig_ubuntu_20
@@ -1,0 +1,76 @@
+eth0: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
+        inet 169.254.4.126  netmask 255.255.255.252  broadcast 169.254.4.127
+        inet6 fe80::215:5dff:fe83:e8ef  prefixlen 64  scopeid 0x20<link>
+        ether 00:15:5d:83:e8:ef  txqueuelen 1000  (Ethernet)
+        RX packets 1673312  bytes 202028712 (202.0 MB)
+        RX errors 0  dropped 0  overruns 0  frame 0
+        TX packets 1411986  bytes 520436601 (520.4 MB)
+        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
+
+eth0:0: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
+        inet 169.254.24.37  netmask 255.255.255.255  broadcast 169.254.24.37
+        ether 00:15:5d:83:e8:ef  txqueuelen 1000  (Ethernet)
+
+eth0:1: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
+        inet 169.254.24.40  netmask 255.255.255.255  broadcast 169.254.24.40
+        ether 00:15:5d:83:e8:ef  txqueuelen 1000  (Ethernet)
+
+eth0:2: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
+        inet 169.254.24.41  netmask 255.255.255.255  broadcast 169.254.24.41
+        ether 00:15:5d:83:e8:ef  txqueuelen 1000  (Ethernet)
+
+eth0:3: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
+        inet 169.254.24.42  netmask 255.255.255.255  broadcast 169.254.24.42
+        ether 00:15:5d:83:e8:ef  txqueuelen 1000  (Ethernet)
+
+eth0:4: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
+        inet 169.254.24.47  netmask 255.255.255.255  broadcast 169.254.24.47
+        ether 00:15:5d:83:e8:ef  txqueuelen 1000  (Ethernet)
+
+eth0:5: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
+        inet 169.254.24.69  netmask 255.255.255.255  broadcast 169.254.24.69
+        ether 00:15:5d:83:e8:ef  txqueuelen 1000  (Ethernet)
+
+eth0:7: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
+        inet 179.127.8.123  netmask 255.255.255.255  broadcast 179.127.8.123
+        ether 00:15:5d:83:e8:ef  txqueuelen 1000  (Ethernet)
+
+eth0:8: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
+        inet 169.254.9.15  netmask 255.255.255.255  broadcast 169.254.9.15
+        ether 00:15:5d:83:e8:ef  txqueuelen 1000  (Ethernet)
+
+eth1: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
+        inet 10.16.17.61  netmask 255.255.255.0  broadcast 10.16.17.255
+        inet6 fe80::215:5dff:fe83:e8f0  prefixlen 64  scopeid 0x20<link>
+        ether 00:15:5d:83:e8:f0  txqueuelen 1000  (Ethernet)
+        RX packets 495129  bytes 267642668 (267.6 MB)
+        RX errors 0  dropped 179  overruns 0  frame 0
+        TX packets 67005  bytes 13963317 (13.9 MB)
+        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
+
+eth2: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
+        inet 10.100.6.2  netmask 255.255.255.0  broadcast 10.100.6.255
+        inet6 fe80::215:5dff:fe83:e8f1  prefixlen 64  scopeid 0x20<link>
+        ether 00:15:5d:83:e8:f1  txqueuelen 1000  (Ethernet)
+        RX packets 22056  bytes 12832001 (12.8 MB)
+        RX errors 0  dropped 0  overruns 0  frame 0
+        TX packets 13989  bytes 2640770 (2.6 MB)
+        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
+
+eth3: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
+        inet 192.168.4.107  netmask 255.255.255.0  broadcast 192.168.4.255
+        inet6 fe80::215:5dff:fe83:e8f2  prefixlen 64  scopeid 0x20<link>
+        ether 00:15:5d:83:e8:f2  txqueuelen 1000  (Ethernet)
+        RX packets 2653583  bytes 179116997 (179.1 MB)
+        RX errors 0  dropped 0  overruns 0  frame 0
+        TX packets 955904  bytes 62158868 (62.1 MB)
+        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
+
+lo: flags=73<UP,LOOPBACK,RUNNING>  mtu 65536
+        inet 127.0.0.1  netmask 255.0.0.0
+        inet6 ::1  prefixlen 128  scopeid 0x10<host>
+        loop  txqueuelen 1000  (Local Loopback)
+        RX packets 49  bytes 3322 (3.3 KB)
+        RX errors 0  dropped 0  overruns 0  frame 0
+        TX packets 49  bytes 3322 (3.3 KB)
+        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0

--- a/test/distros_examples/ip_addr_ubuntu_12
+++ b/test/distros_examples/ip_addr_ubuntu_12
@@ -1,0 +1,56 @@
+1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN 
+    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
+    inet 127.0.0.1/8 scope host lo
+       valid_lft forever preferred_lft forever
+    inet6 ::1/128 scope host 
+       valid_lft forever preferred_lft forever
+2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP qlen 1000
+    link/ether 00:15:5d:83:e8:d1 brd ff:ff:ff:ff:ff:ff
+    inet 192.168.4.89/24 brd 192.168.4.255 scope global eth0
+       valid_lft forever preferred_lft forever
+    inet6 fe80::215:5dff:fe83:e8d1/64 scope link tentative dadfailed 
+       valid_lft forever preferred_lft forever
+3: eth1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP qlen 1000
+    link/ether 00:15:5d:83:e8:d2 brd ff:ff:ff:ff:ff:ff
+    inet 10.100.2.196/24 brd 10.100.2.255 scope global eth1
+       valid_lft forever preferred_lft forever
+    inet6 fe80::215:5dff:fe83:e8d2/64 scope link tentative dadfailed 
+       valid_lft forever preferred_lft forever
+4: eth2: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP qlen 1000
+    link/ether 00:15:5d:83:e8:d3 brd ff:ff:ff:ff:ff:ff
+    inet 10.100.6.10/24 brd 10.100.6.255 scope global eth2
+       valid_lft forever preferred_lft forever
+    inet6 fe80::215:5dff:fe83:e8d3/64 scope link tentative dadfailed 
+       valid_lft forever preferred_lft forever
+5: eth3: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP qlen 1000
+    link/ether 00:15:5d:83:e8:d4 brd ff:ff:ff:ff:ff:ff
+    inet 10.100.7.6/24 brd 10.100.7.255 scope global eth3
+       valid_lft forever preferred_lft forever
+    inet6 fe80::215:5dff:fe83:e8d4/64 scope link tentative dadfailed 
+       valid_lft forever preferred_lft forever
+6: eth4: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP qlen 1000
+    link/ether 00:15:5d:83:e8:d5 brd ff:ff:ff:ff:ff:ff
+    inet 10.150.0.35/24 brd 10.150.0.255 scope global eth4
+       valid_lft forever preferred_lft forever
+    inet6 fe80::215:5dff:fe83:e8d5/64 scope link tentative dadfailed 
+       valid_lft forever preferred_lft forever
+7: eth5: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP qlen 1000
+    link/ether 00:15:5d:83:e8:d6 brd ff:ff:ff:ff:ff:ff
+    inet 192.168.6.221/24 brd 192.168.6.255 scope global eth5
+       valid_lft forever preferred_lft forever
+    inet6 fe80::215:5dff:fe83:e8d6/64 scope link tentative dadfailed 
+       valid_lft forever preferred_lft forever
+8: eth6: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP qlen 1000
+    link/ether 00:15:5d:83:e8:d7 brd ff:ff:ff:ff:ff:ff
+    inet 10.66.0.9/20 brd 10.66.15.255 scope global eth6
+       valid_lft forever preferred_lft forever
+    inet6 fe80::215:5dff:fe83:e8d7/64 scope link tentative dadfailed 
+       valid_lft forever preferred_lft forever
+9: eth7: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP qlen 1000
+    link/ether 00:15:5d:83:e8:d8 brd ff:ff:ff:ff:ff:ff
+    inet 10.16.17.55/24 brd 10.16.17.255 scope global eth7
+       valid_lft forever preferred_lft forever
+    inet 128.1.1.1/24 brd 128.1.1.255 scope global eth7:0
+       valid_lft forever preferred_lft forever
+    inet6 fe80::215:5dff:fe83:e8d8/64 scope link tentative dadfailed 
+       valid_lft forever preferred_lft forever

--- a/test/distros_examples/ip_addr_ubuntu_20
+++ b/test/distros_examples/ip_addr_ubuntu_20
@@ -1,0 +1,48 @@
+1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default qlen 1000
+    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
+    inet 127.0.0.1/8 scope host lo
+       valid_lft forever preferred_lft forever
+    inet6 ::1/128 scope host 
+       valid_lft forever preferred_lft forever
+2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc mq state UP group default qlen 1000
+    link/ether 00:15:5d:83:e8:ef brd ff:ff:ff:ff:ff:ff
+    inet 169.254.4.126/30 brd 169.254.4.127 scope global eth0
+       valid_lft forever preferred_lft forever
+    inet 169.254.24.37/32 brd 169.254.24.37 scope global eth0:0
+       valid_lft forever preferred_lft forever
+    inet 169.254.24.40/32 brd 169.254.24.40 scope global eth0:1
+       valid_lft forever preferred_lft forever
+    inet 169.254.24.41/32 brd 169.254.24.41 scope global eth0:2
+       valid_lft forever preferred_lft forever
+    inet 169.254.24.42/32 brd 169.254.24.42 scope global eth0:3
+       valid_lft forever preferred_lft forever
+    inet 169.254.24.47/32 brd 169.254.24.47 scope global eth0:4
+       valid_lft forever preferred_lft forever
+    inet 169.254.24.69/32 brd 169.254.24.69 scope global eth0:5
+       valid_lft forever preferred_lft forever
+    inet 179.127.8.123/32 brd 179.127.8.123 scope global eth0:7
+       valid_lft forever preferred_lft forever
+    inet 169.254.9.15/32 brd 169.254.9.15 scope global eth0:8
+       valid_lft forever preferred_lft forever
+    inet6 fe80::215:5dff:fe83:e8ef/64 scope link 
+       valid_lft forever preferred_lft forever
+3: eth1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc mq state UP group default qlen 1000
+    link/ether 00:15:5d:83:e8:f0 brd ff:ff:ff:ff:ff:ff
+    inet 10.16.17.61/24 brd 10.16.17.255 scope global eth1
+       valid_lft forever preferred_lft forever
+    inet6 fe80::215:5dff:fe83:e8f0/64 scope link 
+       valid_lft forever preferred_lft forever
+4: eth2: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc mq state UP group default qlen 1000
+    link/ether 00:15:5d:83:e8:f1 brd ff:ff:ff:ff:ff:ff
+    inet 10.100.6.2/24 brd 10.100.6.255 scope global eth2
+       valid_lft forever preferred_lft forever
+    inet6 fe80::215:5dff:fe83:e8f1/64 scope link 
+       valid_lft forever preferred_lft forever
+5: eth3: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc mq state UP group default qlen 1000
+    link/ether 00:15:5d:83:e8:f2 brd ff:ff:ff:ff:ff:ff
+    inet 192.168.4.107/24 brd 192.168.4.255 scope global eth3
+       valid_lft forever preferred_lft forever
+    inet6 fe80::215:5dff:fe83:e8f2/64 scope link 
+       valid_lft forever preferred_lft forever
+6: eth4: <BROADCAST,MULTICAST> mtu 1500 qdisc noop state DOWN group default qlen 1000
+    link/ether 00:15:5d:83:e8:f3 brd ff:ff:ff:ff:ff:ff

--- a/test/distros_examples/ip_link_ubuntu_12
+++ b/test/distros_examples/ip_link_ubuntu_12
@@ -1,0 +1,18 @@
+1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN 
+    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
+2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP qlen 1000
+    link/ether 00:15:5d:83:e8:d1 brd ff:ff:ff:ff:ff:ff
+3: eth1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP qlen 1000
+    link/ether 00:15:5d:83:e8:d2 brd ff:ff:ff:ff:ff:ff
+4: eth2: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP qlen 1000
+    link/ether 00:15:5d:83:e8:d3 brd ff:ff:ff:ff:ff:ff
+5: eth3: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP qlen 1000
+    link/ether 00:15:5d:83:e8:d4 brd ff:ff:ff:ff:ff:ff
+6: eth4: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP qlen 1000
+    link/ether 00:15:5d:83:e8:d5 brd ff:ff:ff:ff:ff:ff
+7: eth5: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP qlen 1000
+    link/ether 00:15:5d:83:e8:d6 brd ff:ff:ff:ff:ff:ff
+8: eth6: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP qlen 1000
+    link/ether 00:15:5d:83:e8:d7 brd ff:ff:ff:ff:ff:ff
+9: eth7: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP qlen 1000
+    link/ether 00:15:5d:83:e8:d8 brd ff:ff:ff:ff:ff:ff

--- a/test/distros_examples/ip_link_ubuntu_20
+++ b/test/distros_examples/ip_link_ubuntu_20
@@ -1,0 +1,12 @@
+1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN mode DEFAULT group default qlen 1000
+    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
+2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc mq state UP mode DEFAULT group default qlen 1000
+    link/ether 00:15:5d:83:e8:ef brd ff:ff:ff:ff:ff:ff
+3: eth1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc mq state UP mode DEFAULT group default qlen 1000
+    link/ether 00:15:5d:83:e8:f0 brd ff:ff:ff:ff:ff:ff
+4: eth2: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc mq state UP mode DEFAULT group default qlen 1000
+    link/ether 00:15:5d:83:e8:f1 brd ff:ff:ff:ff:ff:ff
+5: eth3: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc mq state UP mode DEFAULT group default qlen 1000
+    link/ether 00:15:5d:83:e8:f2 brd ff:ff:ff:ff:ff:ff
+6: eth4: <BROADCAST,MULTICAST> mtu 1500 qdisc noop state DOWN mode DEFAULT group default qlen 1000
+    link/ether 00:15:5d:83:e8:f3 brd ff:ff:ff:ff:ff:ff


### PR DESCRIPTION
- fixed vnetgen for newer linux distros to prioritize ip over ipconfig 
- added 'ifconfig | grep mtu' alternative to 'ifconfig | grep Link' as newer ifconfig doesn't have Link text anymore
- added unit folder with some examples of each distro (to be completed) so it will be possible to test APF code over old distros, as well maybe creating some unit tests on future
- fixed small typo on Ubuntu name on README