### PR TITLE
APF 2.0.2 (re-release): install.sh symlink farm migration fix

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -106,6 +106,13 @@
       dir-to-symlink extraction failure; clean pre-decomposition files and
       runtime state on removal; fix SysV init double-stop on RHEL; DEB adds
       util-linux dependency for flock
+[Fix] install.sh: graceful migration from RPM/DEB FHS symlink farm. Detects
+      and removes /etc/apf/{extras,doc} dir symlinks plus per-file symlinks
+      under internals/ and vnet/vnetgen pointing into /usr/lib/apf or
+      /usr/share/doc/apf before pkg_copy_tree. Without this, install.sh over
+      a package-managed install failed with "cp: cannot overwrite
+      non-directory" and would silently write through per-file symlinks into
+      package-managed paths. User-created symlinks are preserved.
 [Fix] Trust validation: anchor grep/sed patterns to prevent IP substring
       collisions; glob expansion protection in trust_parse_fields(); control
       character and metacharacter rejection in valid_trust_entry(); add hint

--- a/CHANGELOG.RELEASE
+++ b/CHANGELOG.RELEASE
@@ -106,6 +106,13 @@
       dir-to-symlink extraction failure; clean pre-decomposition files and
       runtime state on removal; fix SysV init double-stop on RHEL; DEB adds
       util-linux dependency for flock
+[Fix] install.sh: graceful migration from RPM/DEB FHS symlink farm. Detects
+      and removes /etc/apf/{extras,doc} dir symlinks plus per-file symlinks
+      under internals/ and vnet/vnetgen pointing into /usr/lib/apf or
+      /usr/share/doc/apf before pkg_copy_tree. Without this, install.sh over
+      a package-managed install failed with "cp: cannot overwrite
+      non-directory" and would silently write through per-file symlinks into
+      package-managed paths. User-created symlinks are preserved.
 [Fix] Trust validation: anchor grep/sed patterns to prevent IP substring
       collisions; glob expansion protection in trust_parse_fields(); control
       character and metacharacter rejection in valid_trust_entry(); add hint

--- a/install.sh
+++ b/install.sh
@@ -31,6 +31,14 @@ PKG_BACKUP_METHOD="copy"
 install() {
 	command mkdir -p "$INSTALL_PATH" || { pkg_error "cannot create $INSTALL_PATH"; exit 1; }
 
+	# Convert RPM/DEB FHS symlink farm to flat layout before copying:
+	# RPM/DEB ship extras/doc as dir symlinks into /usr/lib/apf and
+	# /usr/share/doc/apf, plus per-file symlinks in internals/ and
+	# vnet/vnetgen. cp -pR cannot overwrite a symlink-to-dir with a
+	# directory; per-file symlinks would silently write through and
+	# corrupt the package-managed copies under /usr/lib/apf.
+	_migrate_fhs_symlinks "$INSTALL_PATH"
+
 	# Copy source files to install path
 	pkg_copy_tree "files" "$INSTALL_PATH" || { pkg_error "file copy failed"; exit 1; }
 
@@ -135,6 +143,40 @@ install() {
 	"$INSTALL_PATH/vnet/vnetgen" 2>/dev/null  # safe: may fail in containers without interfaces
 
 	command chmod 750 "$INSTALL_PATH"
+}
+
+# _migrate_fhs_symlinks path — remove RPM/DEB FHS symlink farm under path
+# Targets only symlinks pointing into /usr/lib/apf or /usr/share/doc/apf,
+# leaving any user-created symlinks intact.
+_migrate_fhs_symlinks() {
+	local _root="$1"
+	local _migrated=0
+	local _entry _path _target _link
+	for _entry in extras doc vnet/vnetgen; do
+		_path="${_root}/${_entry}"
+		[ -L "$_path" ] || continue
+		_target=$(readlink "$_path" 2>/dev/null)  # readlink may fail on broken symlinks
+		case "$_target" in
+			/usr/lib/apf/*|/usr/share/doc/apf*)
+				command rm -f "$_path"
+				_migrated=1
+				;;
+		esac
+	done
+	if [ -d "${_root}/internals" ]; then
+		while IFS= read -r _link; do
+			_target=$(readlink "$_link" 2>/dev/null)  # readlink may fail on broken symlinks
+			case "$_target" in
+				/usr/lib/apf/*)
+					command rm -f "$_link"
+					_migrated=1
+					;;
+			esac
+		done < <(find "${_root}/internals" -maxdepth 1 -type l)
+	fi
+	if [ "$_migrated" = "1" ]; then
+		pkg_info "Migrated RPM/DEB symlink farm to install.sh layout"
+	fi
 }
 
 # _disable_conflicting_service name — stop and disable a conflicting service

--- a/tests/14-install-paths.bats
+++ b/tests/14-install-paths.bats
@@ -419,3 +419,52 @@ teardown_file() {
     [[ "$output" =~ "Default interface:" ]]
     _clean_test_backup
 }
+
+# =====================================================================
+# RPM/DEB FHS symlink farm migration
+#
+# Simulates an existing package-managed install where /etc/apf/{extras,doc}
+# are dir-level symlinks into /usr/lib/apf and /usr/share/doc/apf, plus
+# per-file symlinks in internals/ and vnet/vnetgen. install.sh must convert
+# these to real directories/files before pkg_copy_tree runs.
+# =====================================================================
+
+@test "install.sh converts RPM/DEB FHS symlink farm to flat layout" {
+    _clean_test_backup
+    # Replace install.sh-created dirs/files with RPM-style symlinks
+    rm -rf "$APF_DIR/extras" "$APF_DIR/doc"
+    rm -f "$APF_DIR/vnet/vnetgen" "$APF_DIR/internals/apf_core.sh"
+    ln -s /usr/lib/apf/extras "$APF_DIR/extras"
+    ln -s /usr/share/doc/apf "$APF_DIR/doc"
+    ln -s /usr/lib/apf/vnet/vnetgen "$APF_DIR/vnet/vnetgen"
+    ln -s /usr/lib/apf/internals/apf_core.sh "$APF_DIR/internals/apf_core.sh"
+    # User-created symlink pointing inside the install must be preserved
+    ln -s /tmp/user-target "$APF_DIR/internals/user-symlink"
+    [ -L "$APF_DIR/extras" ]
+    [ -L "$APF_DIR/internals/apf_core.sh" ]
+
+    cd /opt/apf-src
+    local output
+    output=$(INSTALL_PATH="$APF_DIR" bash install.sh 2>&1)
+    [[ "$output" =~ "Migrated RPM/DEB symlink farm" ]]
+
+    # FHS symlinks replaced with real files/dirs
+    [ -d "$APF_DIR/extras" ] && [ ! -L "$APF_DIR/extras" ]
+    [ -d "$APF_DIR/doc" ] && [ ! -L "$APF_DIR/doc" ]
+    [ -f "$APF_DIR/vnet/vnetgen" ] && [ ! -L "$APF_DIR/vnet/vnetgen" ]
+    [ -f "$APF_DIR/internals/apf_core.sh" ] && [ ! -L "$APF_DIR/internals/apf_core.sh" ]
+    # User symlink preserved
+    [ -L "$APF_DIR/internals/user-symlink" ]
+
+    rm -f "$APF_DIR/internals/user-symlink"
+    _clean_test_backup
+}
+
+@test "install.sh on flat layout emits no migration message" {
+    _clean_test_backup
+    cd /opt/apf-src
+    local output
+    output=$(INSTALL_PATH="$APF_DIR" bash install.sh 2>&1)
+    [[ ! "$output" =~ "Migrated RPM/DEB symlink farm" ]]
+    _clean_test_backup
+}


### PR DESCRIPTION
## Summary

Re-release of v2.0.2 with one additional fix:

- `install.sh` now gracefully migrates from RPM/DEB FHS symlink farm to flat layout, fixing `cp: cannot overwrite non-directory` when running `install.sh` over a package-managed install.
- BATS regression test under `tests/14-install-paths.bats` covering the migration and asserting user symlinks are preserved.

Single commit: c24e555.

## Test plan

- [x] Local: bash -n + shellcheck on install.sh
- [x] Debian 12 BATS smoke: 720/720 (incl. 2 new tests)
- [x] Rocky 9 BATS smoke: 720/720 (incl. 2 new tests)
- [x] Live install on habs (production) — clean migration, importconf merge ok
- [x] All 6 release assets rebuilt from this commit (tarball, deb, el7/8/9/10 RPMs)